### PR TITLE
Tackle containers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 xfail_strict = true
 filterwarnings = [
   "error",
+  "ignore::UserWarning",
 ]
 log_cli_level = "INFO"
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 xfail_strict = true
 filterwarnings = [
   "error",
-  "ignore::UserWarning",
+  "once::UserWarning",
 ]
 log_cli_level = "INFO"
 testpaths = [

--- a/src/rootfilespec/bootstrap/TFile.py
+++ b/src/rootfilespec/bootstrap/TFile.py
@@ -160,9 +160,9 @@ class ROOTFile(ROOTSerializable):
         if fVersion <= VersionInfo(6, 2, 2):
             header, buffer = ROOTFile_header_v302.read(buffer)
         elif not fVersion.large:
-            header, buffer = ROOTFile_header_v622_small.read(buffer)  # type: ignore[assignment]
+            header, buffer = ROOTFile_header_v622_small.read(buffer)
         else:
-            header, buffer = ROOTFile_header_v622_large.read(buffer)  # type: ignore[assignment]
+            header, buffer = ROOTFile_header_v622_large.read(buffer)
         padding, buffer = buffer.consume(header.fBEGIN - buffer.relpos)
         members["magic"] = magic
         members["fVersion"] = fVersion

--- a/src/rootfilespec/bootstrap/TKey.py
+++ b/src/rootfilespec/bootstrap/TKey.py
@@ -136,7 +136,7 @@ class TKey(ROOTSerializable):
             if dyntype is None:
                 msg = f"TKey.read_object: unknown type {typename}."
                 raise NotImplementedError(msg)
-            obj, buffer = dyntype.read(buffer)  # type: ignore[assignment]
+            obj, buffer = dyntype.read(buffer)
         # Some types we have to handle trailing bytes
         if typename == "TKeyList":
             # TODO: understand this padding
@@ -154,4 +154,5 @@ class TKey(ROOTSerializable):
             msg += f"\n{obj=}"
             msg += f"\nBuffer: {buffer}"
             raise ValueError(msg)
-        return obj
+        # mypy doesn't understand that we have obj: ObjType | ROOTSerializable here
+        return obj  # type: ignore[no-any-return]

--- a/src/rootfilespec/bootstrap/TKey.py
+++ b/src/rootfilespec/bootstrap/TKey.py
@@ -134,7 +134,7 @@ class TKey(ROOTSerializable):
             typename = normalize(self.fClassName.fString)
             dyntype = DICTIONARY.get(typename)
             if dyntype is None:
-                msg = f"TKey.read_object: unknown type {typename}."
+                msg = f"TKey.read_object: unknown type {typename}"
                 raise NotImplementedError(msg)
             obj, buffer = dyntype.read(buffer)
         # Some types we have to handle trailing bytes

--- a/src/rootfilespec/bootstrap/TList.py
+++ b/src/rootfilespec/bootstrap/TList.py
@@ -48,8 +48,12 @@ class TList(TSeqCollection):
             # No idea why there is a null pad byte here
             pad, buffer = buffer.consume(1)
             if pad != b"\x00":
-                msg = f"Expected null pad byte but got {pad!r}"
-                raise ValueError(msg)
+                if pad == b"\x01":
+                    # TODO: understand this case (e.g. uproot-issue-350.root)
+                    (mystery,), buffer = buffer.unpack(">B")
+                else:
+                    msg = f"Unexpected pad byte in TList: {pad!r}"
+                    raise ValueError(msg)
             items.append(item)
         members["items"] = items
         return members, buffer

--- a/src/rootfilespec/bootstrap/TList.py
+++ b/src/rootfilespec/bootstrap/TList.py
@@ -1,6 +1,6 @@
-from typing import Annotated
+from typing import Annotated, Union
 
-from rootfilespec.bootstrap.streamedobject import read_streamed_item
+from rootfilespec.bootstrap.streamedobject import Ref, read_streamed_item
 from rootfilespec.bootstrap.strings import TString
 from rootfilespec.bootstrap.TObject import TObject
 from rootfilespec.buffer import ReadBuffer
@@ -33,16 +33,16 @@ class TList(TSeqCollection):
     Reference: https://root.cern/doc/master/streamerinfo.html (TList section)
     """
 
-    items: tuple[TObject, ...]
+    items: list[Union[TObject, Ref[TObject]]]
     """List of objects."""
 
     @classmethod
     def update_members(cls, members: Members, buffer: ReadBuffer):
-        items: list[TObject] = []
+        items: list[Union[TObject, Ref[TObject]]] = []
         fSize: int = members["fSize"]
         for _ in range(fSize):
             item, buffer = read_streamed_item(buffer)
-            if not isinstance(item, TObject):
+            if not (isinstance(item, (TObject, Ref))):
                 msg = f"Expected TObject but got {item!r}"
                 raise ValueError(msg)
             # No idea why there is a null pad byte here
@@ -51,7 +51,7 @@ class TList(TSeqCollection):
                 msg = f"Expected null pad byte but got {pad!r}"
                 raise ValueError(msg)
             items.append(item)
-        members["items"] = tuple(items)
+        members["items"] = items
         return members, buffer
 
 

--- a/src/rootfilespec/bootstrap/TStreamerInfo.py
+++ b/src/rootfilespec/bootstrap/TStreamerInfo.py
@@ -41,6 +41,7 @@ class TStreamerInfo(TNamed):
     def class_definition(self) -> ClassDef:
         """Get the class definition code of this streamer info."""
         bases = self.base_classes()
+        # TODO: f"_VERSION = {self.fClassVersion}"
         members: list[str] = []
         dependencies: list[str] = []
         for element in self.fObjects.objects:

--- a/src/rootfilespec/bootstrap/TStreamerInfo.py
+++ b/src/rootfilespec/bootstrap/TStreamerInfo.py
@@ -400,12 +400,13 @@ class TStreamerObjectPointer(TStreamerElement):
         if self.fArrayLength > 0:
             msg = f"Array length {self.fArrayLength} not implemented for {self.__class__.__name__}"
             raise NotImplementedError(msg)
-        typename = normalize(self.fTypeName.fString)
+        assert self.fTypeName.fString.endswith(b"*")
+        typename = normalize(self.fTypeName.fString.removesuffix(b"*"))
         dependencies = {typename}
         if typename == parent.class_name():
             dependencies.remove(typename)
             typename = f'"{typename}"'
-        mdef = f"{self.member_name()}: Annotated[Ref[{typename}], Pointer()]"
+        mdef = f"{self.member_name()}: Ref[{typename}]"
         return mdef, list(dependencies)
 
 
@@ -454,11 +455,14 @@ class TStreamerObjectAnyPointer(TStreamerElement):
         if self.fArrayLength > 0:
             msg = f"Array length {self.fArrayLength} not implemented for {self.__class__.__name__}"
             raise NotImplementedError(msg)
-        typename, dependencies = cpptype_to_pytype(self.fTypeName.fString)
+        assert self.fTypeName.fString.endswith(b"*")
+        typename, dependencies = cpptype_to_pytype(
+            self.fTypeName.fString.removesuffix(b"*")
+        )
         if typename == parent.class_name():
             dependencies.remove(typename)
             typename = f'"{typename}"'
-        mdef = f"{self.member_name()}: Annotated[Ref[{typename}], Pointer()]"
+        mdef = f"{self.member_name()}: Ref[{typename}]"
         return mdef, list(dependencies)
 
 

--- a/src/rootfilespec/bootstrap/TStreamerInfo.py
+++ b/src/rootfilespec/bootstrap/TStreamerInfo.py
@@ -400,7 +400,8 @@ class TStreamerObjectPointer(TStreamerElement):
         if self.fArrayLength > 0:
             msg = f"Array length {self.fArrayLength} not implemented for {self.__class__.__name__}"
             raise NotImplementedError(msg)
-        typename, dependencies = cpptype_to_pytype(self.fTypeName.fString)
+        typename = normalize(self.fTypeName.fString)
+        dependencies = {typename}
         if typename == parent.class_name():
             dependencies.remove(typename)
             typename = f'"{typename}"'

--- a/src/rootfilespec/bootstrap/TStreamerInfo.py
+++ b/src/rootfilespec/bootstrap/TStreamerInfo.py
@@ -553,6 +553,9 @@ DICTIONARY["TStreamerSTL"] = TStreamerSTL
 class TStreamerSTLstring(TStreamerSTL):
     """STL string streamer element."""
 
+    def member_definition(self, parent: TStreamerInfo):  # noqa: ARG002
+        return f"{self.member_name()}: STLString", []
+
 
 # the lower case "string" is intentional
 DICTIONARY["TStreamerSTLstring"] = TStreamerSTLstring

--- a/src/rootfilespec/bootstrap/TStreamerInfo.py
+++ b/src/rootfilespec/bootstrap/TStreamerInfo.py
@@ -351,7 +351,7 @@ DICTIONARY["TStreamerBasicType"] = TStreamerBasicType
 class TStreamerString(TStreamerElement):
     def member_definition(self, parent: TStreamerInfo):  # noqa: ARG002
         if self.fArrayLength > 0:
-            msg = f"Array length {self.fArrayLength} not implemented for {self.__class__.__name__}"
+            msg = f"Array length not implemented for {self.__class__.__name__}"
             raise NotImplementedError(msg)
         return f"{self.member_name()}: TString", []
 
@@ -375,7 +375,7 @@ class TStreamerBasicPointer(TStreamerElement):
 
     def member_definition(self, parent: TStreamerInfo):
         if self.fArrayLength > 0:
-            msg = f"Array length {self.fArrayLength} not implemented for {self.__class__.__name__}"
+            msg = f"Array length not implemented for {self.__class__.__name__}"
             raise NotImplementedError(msg)
 
         fmt = ElementType(self.fType - ElementType.kOffsetP).as_fmt()
@@ -401,7 +401,7 @@ DICTIONARY["TStreamerBasicPointer"] = TStreamerBasicPointer
 class TStreamerObject(TStreamerElement):
     def member_definition(self, parent: TStreamerInfo):
         if self.fArrayLength > 0:
-            msg = f"Array length {self.fArrayLength} not implemented for {self.__class__.__name__}"
+            msg = f"Array length not implemented for {self.__class__.__name__}"
             raise NotImplementedError(msg)
         typename = self.type_name()
         dependencies = []
@@ -422,15 +422,15 @@ DICTIONARY["TStreamerObject"] = TStreamerObject
 class TStreamerObjectPointer(TStreamerElement):
     def member_definition(self, parent: TStreamerInfo):
         if self.fArrayLength > 0:
-            msg = f"Array length {self.fArrayLength} not implemented for {self.__class__.__name__}"
+            msg = f"Array length not implemented for {self.__class__.__name__}"
             raise NotImplementedError(msg)
         assert self.fTypeName.fString.endswith(b"*")
-        typename = normalize(self.fTypeName.fString.removesuffix(b"*"))
-        dependencies = {typename}
-        if typename == parent.class_name():
-            dependencies.remove(typename)
-            typename = f'"{typename}"'
-        mdef = f"{self.member_name()}: Ref[{typename}]"
+        typename, dependencies = cpptype_to_pytype(self.fTypeName.fString)
+        this = parent.class_name()
+        if this in dependencies:
+            dependencies.remove(this)
+            typename = typename.replace(this, f'"{this}"')
+        mdef = f"{self.member_name()}: {typename}"
         return mdef, list(dependencies)
 
 
@@ -459,7 +459,7 @@ DICTIONARY["TStreamerLoop"] = TStreamerLoop
 class TStreamerObjectAny(TStreamerElement):
     def member_definition(self, parent: TStreamerInfo):
         if self.fArrayLength > 0:
-            msg = f"Array length {self.fArrayLength} not implemented for {self.__class__.__name__}"
+            msg = f"Array length not implemented for {self.__class__.__name__}"
             raise NotImplementedError(msg)
         if self.type_name() == parent.class_name():
             typename = f'"{self.type_name()}"'
@@ -477,7 +477,7 @@ DICTIONARY["TStreamerObjectAny"] = TStreamerObjectAny
 class TStreamerObjectAnyPointer(TStreamerElement):
     def member_definition(self, parent: TStreamerInfo):
         if self.fArrayLength > 0:
-            msg = f"Array length {self.fArrayLength} not implemented for {self.__class__.__name__}"
+            msg = f"Array length not implemented for {self.__class__.__name__}"
             raise NotImplementedError(msg)
         assert self.fTypeName.fString.endswith(b"*")
         typename, dependencies = cpptype_to_pytype(

--- a/src/rootfilespec/bootstrap/__init__.py
+++ b/src/rootfilespec/bootstrap/__init__.py
@@ -16,7 +16,6 @@ from rootfilespec.bootstrap.array import (
 )
 from rootfilespec.bootstrap.assumed import (
     RooLinkedList,
-    ROOT3a3aTIOFeatures,
     TAtt3D,
     TVirtualIndex,
     Uninterpreted,
@@ -52,7 +51,6 @@ __all__ = [
     "RCompressed",
     "RCompressionHeader",
     "ROOT3a3aRNTuple",
-    "ROOT3a3aTIOFeatures",
     "ROOTFile",
     "Ref",
     "RooLinkedList",

--- a/src/rootfilespec/bootstrap/__init__.py
+++ b/src/rootfilespec/bootstrap/__init__.py
@@ -22,7 +22,7 @@ from rootfilespec.bootstrap.assumed import (
 )
 from rootfilespec.bootstrap.compression import RCompressed, RCompressionHeader
 from rootfilespec.bootstrap.RAnchor import ROOT3a3aRNTuple
-from rootfilespec.bootstrap.streamedobject import Pointer, Ref, StreamedObject
+from rootfilespec.bootstrap.streamedobject import Ref, StreamedObject
 from rootfilespec.bootstrap.strings import STLString, TString, string
 from rootfilespec.bootstrap.TBasket import TBasket
 from rootfilespec.bootstrap.TDatime import TDatime
@@ -48,7 +48,6 @@ from rootfilespec.bootstrap.TStreamerInfo import (
 )
 
 __all__ = [
-    "Pointer",
     "RCompressed",
     "RCompressionHeader",
     "ROOT3a3aRNTuple",

--- a/src/rootfilespec/bootstrap/__init__.py
+++ b/src/rootfilespec/bootstrap/__init__.py
@@ -14,7 +14,12 @@ from rootfilespec.bootstrap.array import (
     TArrayI,
     TArrayS,
 )
-from rootfilespec.bootstrap.assumed import ROOT3a3aTIOFeatures, TAtt3D, TVirtualIndex
+from rootfilespec.bootstrap.assumed import (
+    ROOT3a3aTIOFeatures,
+    TAtt3D,
+    TVirtualIndex,
+    Uninterpreted,
+)
 from rootfilespec.bootstrap.compression import RCompressed, RCompressionHeader
 from rootfilespec.bootstrap.RAnchor import ROOT3a3aRNTuple
 from rootfilespec.bootstrap.streamedobject import Pointer, Ref, StreamedObject
@@ -84,5 +89,6 @@ __all__ = [
     "TStreamerString",
     "TString",
     "TVirtualIndex",
+    "Uninterpreted",
     "string",
 ]

--- a/src/rootfilespec/bootstrap/__init__.py
+++ b/src/rootfilespec/bootstrap/__init__.py
@@ -23,7 +23,7 @@ from rootfilespec.bootstrap.assumed import (
 from rootfilespec.bootstrap.compression import RCompressed, RCompressionHeader
 from rootfilespec.bootstrap.RAnchor import ROOT3a3aRNTuple
 from rootfilespec.bootstrap.streamedobject import Pointer, Ref, StreamedObject
-from rootfilespec.bootstrap.strings import TString, string
+from rootfilespec.bootstrap.strings import STLString, TString, string
 from rootfilespec.bootstrap.TBasket import TBasket
 from rootfilespec.bootstrap.TDatime import TDatime
 from rootfilespec.bootstrap.TDirectory import TDirectory, TKeyList
@@ -55,6 +55,7 @@ __all__ = [
     "ROOT3a3aTIOFeatures",
     "ROOTFile",
     "Ref",
+    "STLString",
     "StreamedObject",
     "TArrayC",
     "TArrayD",

--- a/src/rootfilespec/bootstrap/__init__.py
+++ b/src/rootfilespec/bootstrap/__init__.py
@@ -15,6 +15,7 @@ from rootfilespec.bootstrap.array import (
     TArrayS,
 )
 from rootfilespec.bootstrap.assumed import (
+    RooLinkedList,
     ROOT3a3aTIOFeatures,
     TAtt3D,
     TVirtualIndex,
@@ -54,6 +55,7 @@ __all__ = [
     "ROOT3a3aTIOFeatures",
     "ROOTFile",
     "Ref",
+    "RooLinkedList",
     "STLString",
     "StreamedObject",
     "TArrayC",

--- a/src/rootfilespec/bootstrap/assumed.py
+++ b/src/rootfilespec/bootstrap/assumed.py
@@ -5,7 +5,7 @@ TBasket and TArray* are also examples of this, but they are
 implemented in their own files.
 """
 
-from typing import Annotated, Optional
+from typing import Annotated
 
 from rootfilespec.bootstrap.streamedobject import (
     StreamedObject,
@@ -14,7 +14,6 @@ from rootfilespec.bootstrap.streamedobject import (
 )
 from rootfilespec.bootstrap.TObject import TObject
 from rootfilespec.buffer import ReadBuffer
-from rootfilespec.dispatch import DICTIONARY
 from rootfilespec.serializable import Members, ROOTSerializable, serializable
 from rootfilespec.structutil import Fmt
 
@@ -36,26 +35,6 @@ class TAtt3D(StreamedObject):
     So we get "ValueError: Class TH3 depends on TAtt3D, which is not declared"
     Note that the second file also has a suspicious TH1D object with fByteCount == 0
     """
-
-
-@serializable
-class ROOT3a3aTIOFeatures(StreamedObject):
-    fIOBits: int
-    extra: Optional[int]
-
-    @classmethod
-    def update_members(cls, members: Members, buffer: ReadBuffer):
-        (fIOBits,), buffer = buffer.unpack(">B")
-        extra: Optional[int] = None
-        if fIOBits > 0:
-            # TODO: why is this 4 bytes here?
-            (extra,), buffer = buffer.unpack(">i")
-        members["fIOBits"] = fIOBits
-        members["extra"] = extra
-        return members, buffer
-
-
-DICTIONARY["ROOT3a3aTIOFeatures"] = ROOT3a3aTIOFeatures
 
 
 @serializable

--- a/src/rootfilespec/bootstrap/assumed.py
+++ b/src/rootfilespec/bootstrap/assumed.py
@@ -66,8 +66,8 @@ class Uninterpreted(StreamedObject):
 
     @classmethod
     def read(cls, buffer: ReadBuffer):
-        header, buffer = StreamHeader.read(buffer)
-        data, buffer = buffer.consume(header.fByteCount - 4)
+        header, _ = StreamHeader.read(buffer)
+        data, buffer = buffer.consume(header.fByteCount + 4)
         return cls(header, data), buffer
 
     @classmethod

--- a/src/rootfilespec/bootstrap/assumed.py
+++ b/src/rootfilespec/bootstrap/assumed.py
@@ -7,7 +7,7 @@ implemented in their own files.
 
 from typing import Optional
 
-from rootfilespec.bootstrap.streamedobject import StreamedObject
+from rootfilespec.bootstrap.streamedobject import StreamedObject, StreamHeader
 from rootfilespec.buffer import ReadBuffer
 from rootfilespec.dispatch import DICTIONARY
 from rootfilespec.serializable import Members, serializable
@@ -50,3 +50,27 @@ class ROOT3a3aTIOFeatures(StreamedObject):
 
 
 DICTIONARY["ROOT3a3aTIOFeatures"] = ROOT3a3aTIOFeatures
+
+
+@serializable
+class Uninterpreted(StreamedObject):
+    """A class to represent an uninterpreted streamed object
+
+    This is used for objects that are not recognized by the library.
+    """
+
+    header: StreamHeader
+    """The header of the object."""
+    data: bytes
+    """The uninterpreted data of the object."""
+
+    @classmethod
+    def read(cls, buffer: ReadBuffer):
+        header, buffer = StreamHeader.read(buffer)
+        data, buffer = buffer.consume(header.fByteCount - 4)
+        return cls(header, data), buffer
+
+    @classmethod
+    def update_members(cls, members: Members, buffer: ReadBuffer):  # noqa: ARG003
+        msg = "Logic error"
+        raise RuntimeError(msg)

--- a/src/rootfilespec/bootstrap/streamedobject.py
+++ b/src/rootfilespec/bootstrap/streamedobject.py
@@ -158,7 +158,7 @@ def read_streamed_item(
         clsname = normalize(itemheader.fClassName)
         if clsname not in DICTIONARY:
             if clsname == "TLeafI":
-                msg = "TLeafI not declared in StreamerInfo perhaps? e.g. uproot-issue413.root"
+                msg = "TLeafI not declared in StreamerInfo, e.g. uproot-issue413.root"
                 # (84 other test files have it, e.g. uproot-issue121.root)
                 # https://github.com/scikit-hep/uproot3/issues/413
                 # Likely groot-v0.21.0 (Go ROOT file implementation) did not write the streamers for TLeaf
@@ -224,8 +224,8 @@ def _read_all_members(
     else:
         itemheader, buffer = StreamHeader.read(buffer)
         if itemheader.fByteCount == 0:
-            if cls.__name__ in ("TH1D"):
-                msg = "Suspicious object with fByteCount == 0 (e.g. uproot-issue-250.root)"
+            if cls.__name__ in ("TH1D", "TH2D"):
+                msg = "Suspicious THx with fByteCount == 0 (e.g. uproot-issue-250.root)"
                 raise NotImplementedError(msg)
             msg = "fByteCount is 0"
             raise ValueError(msg)

--- a/src/rootfilespec/bootstrap/streamedobject.py
+++ b/src/rootfilespec/bootstrap/streamedobject.py
@@ -1,12 +1,14 @@
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Generic, Optional, TypeVar, get_args, get_origin
+from typing import Generic, Optional, TypeVar, overload
 
 from rootfilespec.buffer import ReadBuffer
 from rootfilespec.dispatch import DICTIONARY, normalize
 from rootfilespec.serializable import (
+    ContainerSerDe,
     Members,
-    MemberSerDe,
+    MemberType,
+    ReadObjMethod,
     ROOTSerializable,
     serializable,
 )
@@ -49,22 +51,20 @@ class StreamHeader(ROOTSerializable):
 
     @classmethod
     def read(cls, buffer: ReadBuffer):
-        # read all we might need in one go and advance later (optimization)
-        (fByteCount, tmp1, tmp2), _ = buffer.unpack(">iHH")
+        (fByteCount,), buffer = buffer.unpack(">i")
         if fByteCount & _StreamConstants.kByteCountMask:
             fByteCount &= ~_StreamConstants.kByteCountMask
         else:
             # This is a reference to another object in the buffer
-            _, buffer = buffer.consume(4)
             return cls(0, None, None, fByteCount), buffer
         fVersion, fClassName, fClassRef = None, None, None
+        (tmp1,), buffer = buffer.unpack(">H")
         if not (tmp1 & _StreamConstants.kNotAVersion):
             fVersion = tmp1
-            _, buffer = buffer.consume(6)  # now advance the buffer
         else:
             fVersion = None
+            (tmp2,), buffer = buffer.unpack(">H")
             fClassInfo: int = (tmp1 << 16) | tmp2
-            _, buffer = buffer.consume(8)  # now advance the buffer
             if fClassInfo == _StreamConstants.kNewClassTag:
                 fClassRef = buffer.relpos - 4
                 fClassName = b""
@@ -87,35 +87,97 @@ class StreamHeader(ROOTSerializable):
         return cls(fByteCount, fVersion, fClassName, fClassRef), buffer
 
 
-def read_streamed_item(buffer: ReadBuffer):
+@dataclass
+class _RefReader:
+    name: str
+    inner_reader: ReadObjMethod
+
+    def __call__(self, members: Members, buffer: ReadBuffer):
+        members[self.name], buffer = read_streamed_item(buffer, self.inner_reader)
+        return members, buffer
+
+
+T = TypeVar("T", bound=MemberType)
+
+
+class Ref(ContainerSerDe, Generic[T]):
+    """A class to hold a reference to an object.
+
+    We cannot use a dataclass here because its repr might end up
+    being cyclic and cause a stack overflow.
+    """
+
+    obj: Optional[T]
+    """The object that is referenced."""
+
+    def __init__(self, obj: Optional[T]):
+        self.obj = obj
+
+    def __repr__(self):
+        label = type(self.obj).__name__ if self.obj else "None"
+        return f"Ref({label})"
+
+    @classmethod
+    def build_reader(cls, fname: str, inner_reader: ReadObjMethod):
+        return _RefReader(fname, inner_reader)
+
+
+@overload
+def read_streamed_item(
+    buffer: ReadBuffer, method: ReadObjMethod
+) -> tuple[Ref[MemberType], ReadBuffer]: ...
+
+
+@overload
+def read_streamed_item(
+    buffer: ReadBuffer,
+) -> tuple[ROOTSerializable, ReadBuffer]: ...
+
+
+def read_streamed_item(
+    buffer: ReadBuffer, method: Optional[ReadObjMethod] = None
+) -> tuple[ROOTSerializable, ReadBuffer]:
     # Read ahead the stream header to determine the type of the object
     itemheader, _ = StreamHeader.read(buffer)
     if itemheader.fByteCount == 0 and itemheader.fClassRef is not None:
-        return _read_ref(buffer)
-    if not itemheader.fClassName:
+        # This is a reference to another object in the buffer
+        if itemheader.fClassRef == 0:
+            # Null reference, return None
+            _, buffer = buffer.consume(4)
+            return Ref(None), buffer
+        # TODO: fetch the referenced object from the buffer.instance_refs
+        _, buffer = buffer.consume(4)
+        return Ref(None), buffer
+    if itemheader.fClassName:
+        clsname = normalize(itemheader.fClassName)
+        if clsname not in DICTIONARY:
+            if clsname == "TLeafI":
+                msg = "TLeafI not declared in StreamerInfo perhaps? e.g. uproot-issue413.root"
+                # (84 other test files have it, e.g. uproot-issue121.root)
+                # https://github.com/scikit-hep/uproot3/issues/413
+                # Likely groot-v0.21.0 (Go ROOT file implementation) did not write the streamers for TLeaf
+                raise NotImplementedError(msg)
+            msg = f"Unknown class name: {itemheader.fClassName}"
+            msg += f"\nStreamHeader: {itemheader}"
+            raise ValueError(msg)
+        dynmethod = DICTIONARY[clsname].read
+    elif method is not None:
+        clsname = f"Ref ({method})"
+
+        def dynmethod(buffer: ReadBuffer) -> tuple[ROOTSerializable, ReadBuffer]:
+            item, buffer = method(buffer)
+            return Ref(item), buffer
+    else:
         msg = f"StreamHeader has no class name: {itemheader}"
         raise ValueError(msg)
-    clsname = normalize(itemheader.fClassName)
-    if clsname not in DICTIONARY:
-        if clsname == "TLeafI":
-            msg = (
-                "TLeafI not declared in StreamerInfo perhaps? e.g. uproot-issue413.root\n"
-                "(84 other test files have it, e.g. uproot-issue121.root)"
-            )
-            # https://github.com/scikit-hep/uproot3/issues/413
-            # Likely groot-v0.21.0 (Go ROOT file implementation) did not write the streamers for TLeaf
-            raise NotImplementedError(msg)
-        msg = f"Unknown class name: {itemheader.fClassName}"
-        msg += f"\nStreamHeader: {itemheader}"
-        raise ValueError(msg)
+
     # Now actually read the object
-    dyntype = DICTIONARY[clsname]
     item_end = itemheader.fByteCount + 4
     buffer, remaining = buffer[:item_end], buffer[item_end:]
-    item, buffer = dyntype.read(buffer)
-    # TODO: register the object addr in the buffer local_refs
+    item, buffer = dynmethod(buffer)
+    # TODO: register the object addr in the buffer instance_refs
     if buffer:
-        msg = f"Expected buffer to be empty after reading {dyntype}, but got\n{buffer}"
+        msg = f"Expected buffer to be empty after reading {clsname}, but got\n{buffer}"
         raise ValueError(msg)
     return item, remaining
 
@@ -132,11 +194,18 @@ def _auto_TObject_base(buffer) -> tuple[StreamHeader, ReadBuffer]:
     return itemheader, buffer
 
 
-T = TypeVar("T", bound="StreamedObject")
+@serializable
+class StreamedObject(ROOTSerializable):
+    """Base class for all streamed objects in ROOT."""
+
+    @classmethod
+    def read(cls, buffer: ReadBuffer):
+        members, buffer = _read_all_members(cls, buffer)
+        return cls(**members), buffer
 
 
 def _read_all_members(
-    cls: type[T], buffer: ReadBuffer, indent=0
+    cls: type[StreamedObject], buffer: ReadBuffer, indent=0
 ) -> tuple[Members, ReadBuffer]:
     start_position = buffer.relpos
     if cls.__name__ == "TObject" and indent > 0:
@@ -146,8 +215,8 @@ def _read_all_members(
     else:
         itemheader, buffer = StreamHeader.read(buffer)
         if itemheader.fByteCount == 0:
-            if cls.__name__ == "TH1D":
-                msg = "Suspicious TH1D object with fByteCount == 0 (e.g. uproot-issue-250.root)"
+            if cls.__name__ in ("TH1D", "RooLinkedList"):
+                msg = "Suspicious object with fByteCount == 0 (e.g. uproot-issue-250.root, uproot-issue49.root)"
                 raise NotImplementedError(msg)
             msg = "fByteCount is 0"
             raise ValueError(msg)
@@ -177,70 +246,3 @@ def _read_all_members(
         msg += f"\nBuffer: {buffer}"
         raise ValueError(msg)
     return members, buffer
-
-
-@serializable
-class StreamedObject(ROOTSerializable):
-    """Base class for all streamed objects in ROOT."""
-
-    @classmethod
-    def read(cls: type[T], buffer: ReadBuffer) -> tuple[T, ReadBuffer]:
-        members, buffer = _read_all_members(cls, buffer)
-        return cls(**members), buffer
-
-
-def _read_ref(buffer: ReadBuffer) -> tuple["Ref[StreamedObject]", ReadBuffer]:
-    # TODO: implement getting the ref from buffer.local_refs
-    return Ref(None), buffer[4:]
-
-
-class Ref(ROOTSerializable, Generic[T]):
-    """A class to hold a reference to an object.
-
-    We cannot use a dataclass here because its repr might end up
-    being cyclic and cause a stack overflow.
-    """
-
-    obj: Optional[T]
-    """The object that is referenced."""
-
-    def __init__(self, obj: Optional[T]):
-        self.obj = obj
-
-    def __repr__(self):
-        label = type(self.obj).__name__ if self.obj else "None"
-        return f"Ref({label})"
-
-    @classmethod
-    def read_as(cls, ftype: type[T], buffer: ReadBuffer):  # noqa: ARG003
-        (addr,), _ = buffer.unpack(">i")
-        if not addr:
-            buffer = buffer[4:]
-            return cls(None), buffer
-        if addr & 0x40000000:
-            # this isn't actually an address but an object
-            addr &= ~0x40000000
-            buffer = buffer[addr + 4 :]
-            return cls(None), buffer
-            # obj, buffer = ftype.read(buffer)
-            # TODO: register the object addr in the buffer local_refs
-            # return cls(obj), buffer
-        return _read_ref(buffer)
-
-
-class Pointer(MemberSerDe):
-    def build_reader(self, fname: str, ftype: type):
-        if (origin := get_origin(ftype)) is not Ref:
-            msg = f"Pointer() only can be used with Ref, got {origin}"
-            raise ValueError(msg)
-        (ftype,) = get_args(ftype)
-        if not issubclass(ftype, StreamedObject):
-            msg = f"Pointer() only can be used with Ref[StreamedObject], got {ftype}"
-            raise ValueError(msg)
-
-        def read(members: Members, buffer: ReadBuffer) -> tuple[Members, ReadBuffer]:
-            obj, buffer = Ref.read_as(ftype, buffer)
-            members[fname] = obj
-            return members, buffer
-
-        return read

--- a/src/rootfilespec/bootstrap/streamedobject.py
+++ b/src/rootfilespec/bootstrap/streamedobject.py
@@ -23,6 +23,8 @@ class _StreamConstants(IntEnum):
     """New class tag"""
     kNotAVersion = 0x8000
     """Either kClassMask or kNewClassTag is set in bytes 4-5"""
+    kStreamedMemberwise = 0x4000
+    """Not sure if this is where it is used"""
 
 
 @dataclass
@@ -40,6 +42,10 @@ class StreamHeader(ROOTSerializable):
     """Class name of object, if first instance of class in buffer"""
     fClassRef: Optional[int]
     """Position in buffer of class name if not specified here"""
+
+    def is_memberwise(self) -> bool:
+        """Check if the object is memberwise streamed"""
+        return bool((self.fVersion or 0) & _StreamConstants.kStreamedMemberwise)
 
     @classmethod
     def read(cls, buffer: ReadBuffer):

--- a/src/rootfilespec/bootstrap/streamedobject.py
+++ b/src/rootfilespec/bootstrap/streamedobject.py
@@ -157,6 +157,9 @@ def read_streamed_item(
                 # https://github.com/scikit-hep/uproot3/issues/413
                 # Likely groot-v0.21.0 (Go ROOT file implementation) did not write the streamers for TLeaf
                 raise NotImplementedError(msg)
+            if clsname == "RooRealVar":
+                msg = "RooRealVar not declared in the StreamerInfo, e.g. uproot-issue49.root"
+                raise NotImplementedError(msg)
             msg = f"Unknown class name: {itemheader.fClassName}"
             msg += f"\nStreamHeader: {itemheader}"
             raise ValueError(msg)

--- a/src/rootfilespec/bootstrap/strings.py
+++ b/src/rootfilespec/bootstrap/strings.py
@@ -1,3 +1,4 @@
+from rootfilespec.bootstrap.streamedobject import StreamedObject
 from rootfilespec.buffer import ReadBuffer
 from rootfilespec.dispatch import DICTIONARY
 from rootfilespec.serializable import Members, ROOTSerializable, serializable
@@ -12,6 +13,9 @@ class TString(ROOTSerializable):
 
     fString: bytes
     """The string data."""
+
+    def __hash__(self) -> int:
+        return hash(self.fString)
 
     @classmethod
     def update_members(cls, members: Members, buffer: ReadBuffer):
@@ -30,11 +34,17 @@ class TString(ROOTSerializable):
         return members, buffer
 
 
+# No examples so far of TString being streamed but it is in most StreamerInfo
 DICTIONARY["TString"] = TString
+
+string = TString
+DICTIONARY["string"] = TString
 
 
 @serializable
-class string(ROOTSerializable):
+class STLString(StreamedObject):
+    """String with a stream header (see also TObjString)"""
+
     value: bytes
 
     @classmethod
@@ -47,4 +57,4 @@ class string(ROOTSerializable):
         return members, buffer
 
 
-DICTIONARY["string"] = string
+DICTIONARY["STLString"] = STLString

--- a/src/rootfilespec/container.py
+++ b/src/rootfilespec/container.py
@@ -167,7 +167,7 @@ class StdVector(ContainerSerDe, Generic[T]):
         if hasheader:
             header, buffer = StreamHeader.read(buffer)
             # TODO: byte count check
-            if header.is_memberwise():
+            if header.memberwise:
                 msg = "Memberwise reading of StdVector not implemented"
                 raise NotImplementedError(msg)
         (n,), buffer = buffer.unpack(">i")
@@ -243,7 +243,7 @@ class StdMap(AssociativeContainerSerDe, Generic[K, V]):
         cls, key_reader: ReadObjMethod, value_reader: ReadObjMethod, buffer: ReadBuffer
     ):
         header, buffer = StreamHeader.read(buffer)
-        if header.is_memberwise():
+        if header.memberwise:
             msg = "Suspicious map with memberwise reading, incorrect length seen in uproot-issue465-flat.root"
             raise NotImplementedError(msg)
         (n,), buffer = buffer.unpack(">i")

--- a/src/rootfilespec/cpptype.py
+++ b/src/rootfilespec/cpptype.py
@@ -45,6 +45,8 @@ _cpp_primitives = {
 }
 _cpp_templates = {
     b"vector": "StdVector",
+    b"map": "StdMap",
+    b"set": "StdSet",
 }
 
 

--- a/src/rootfilespec/cpptype.py
+++ b/src/rootfilespec/cpptype.py
@@ -47,6 +47,8 @@ _cpp_templates = {
     b"vector": "StdVector",
     b"map": "StdMap",
     b"set": "StdSet",
+    b"deque": "StdDeque",
+    b"pair": "StdPair",
 }
 
 

--- a/src/rootfilespec/cpptype.py
+++ b/src/rootfilespec/cpptype.py
@@ -23,9 +23,9 @@ which can be rendered with lark using `python -m lark.tools.standalone cpptype.l
 """
 
 import re
-from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Optional
+from enum import IntEnum
+from typing import Optional, Protocol
 
 from rootfilespec.dispatch import normalize
 
@@ -53,22 +53,48 @@ _cpp_templates: dict[bytes, tuple[str, int]] = {
 }
 
 
-_tokenize = re.compile(rb"([\w:]+)|([<>,\*])|(?:\s+)")
-_Token = tuple[bytes, bytes]
-_ignored_terminals: set[_Token] = {
-    (b"", b""),
-    (b"const", b""),
-    (b"", b"*"),
-    # Workaround for Pypy bug https://github.com/pypy/pypy/issues/5265
-    ("", ""),  # type: ignore[arg-type]
-    (b"const", ""),  # type: ignore[arg-type]
-    ("", b"*"),  # type: ignore[arg-type]
-}
+_tokenize = re.compile(rb"([\w:]+|<| ?>|, ?| ?\*| )")
+
+
+class _TokenType(IntEnum):
+    NAME = 0
+    TEMPLATE_START = 1
+    TEMPLATE_END = 2
+    COMMA = 3
+    POINTER = 4
+    SPACE = 5
+
+
+class _Token:
+    type: _TokenType
+    value: bytes
+
+    def __init__(self, match: bytes):
+        self.value = match
+        if match == b"<":
+            self.type = _TokenType.TEMPLATE_START
+        elif match.endswith(b">"):
+            self.type = _TokenType.TEMPLATE_END
+        elif match.startswith(b","):
+            self.type = _TokenType.COMMA
+        elif match.endswith(b"*"):
+            self.type = _TokenType.POINTER
+        elif match == b" ":
+            self.type = _TokenType.SPACE
+        else:
+            self.type = _TokenType.NAME
+
+    def __repr__(self) -> str:
+        return f"_Token(type={self.type.name}, value={self.value!r})"
 
 
 class _TokenStream:
-    def __init__(self, tokens: Iterable[_Token]):
-        self._tokens = iter(tokens)
+    def __init__(self, input: bytes):
+        split = _tokenize.split(input)
+        if any(split[::2]):
+            msg = f"Unexpected token in C++ type name {input!r}"
+            raise ValueError(msg)
+        self._tokens = iter(_Token(match) for match in split[1::2])
         self._current = next(self._tokens, None)
 
     def peek(self) -> Optional[_Token]:
@@ -79,39 +105,69 @@ class _TokenStream:
         return token
 
 
+NameWithDependencies = tuple[str, set[str]]
+
+
+class _CppTypeAstNode(Protocol):
+    def cppname(self) -> bytes:
+        """Return the C++ name of the type."""
+        ...
+
+    def to_pytype(self) -> NameWithDependencies:
+        """Convert C++ type name to Python type name."""
+        ...
+
+
 @dataclass
-class _CppTypeAstNode:
+class _CppTypeAstName(_CppTypeAstNode):
     name: bytes
 
-    def to_pytype(self) -> tuple[str, set[str]]:
+    def cppname(self) -> bytes:
+        return self.name
+
+    def to_pytype(self) -> NameWithDependencies:
         """Convert C++ type name to Python type name."""
         if self.name in _cpp_primitives:
-            return _cpp_primitives[self.name], set()
+            deps: set[str] = set()
+            return _cpp_primitives[self.name], deps
         pyname = normalize(self.name)
         return pyname, {pyname}
 
 
 @dataclass
-class _CppTypeAstTemplate(_CppTypeAstNode):
+class _CppTypeAstTemplate(_CppTypeAstName):
     args: tuple[_CppTypeAstNode, ...]
 
-    def to_pytype(self):
+    def cppname(self) -> bytes:
+        args = b",".join(arg.cppname() for arg in self.args)
+        close = b">"
+        if isinstance(self.args[-1], _CppTypeAstTemplate):
+            close = b" >"
+        return self.name + b"<" + args + close
+
+    def to_pytype(self) -> NameWithDependencies:
         """Convert C++ type name to Python type name."""
-        if self.name in _cpp_templates:
-            pyname, nargs = _cpp_templates[self.name]
-        elif self.name == b"bitset":
+        deps: set[str] = set()
+        if self.name == b"bitset":
             argn, *rest = self.args
             if rest:
                 msg = "bitset template has too many arguments"
                 raise ValueError(msg)
+            if not isinstance(argn, _CppTypeAstName):
+                msg = "bitset template argument must be a name"
+                raise ValueError(msg)
             n = int(argn.name)
             pyname = f"Annotated[int, StdBitset({n})]"
-            return pyname, set()
-        else:
-            msg = f"Template type {self.name!r} not implemented"
-            raise NotImplementedError(msg)
+            return pyname, deps
+        if self.name not in _cpp_templates:
+            # This is probably a templated data member and not a container type
+            # So it should be in the dictionary and we just have to normalize the name
+            # TODO: is there any way to tell when we have a container or not?
+            pyname = normalize(self.cppname())
+            return pyname, {pyname}
+        # This is a C++ template type we know how to handle
+        pyname, nargs = _cpp_templates[self.name]
         args = []
-        deps: set[str] = set()
         if len(self.args) > nargs:
             # TODO: warn when we have extra arguments?
             # these can be e.g. the comparison argument in std::map (defaults to std::less<Key>)
@@ -123,6 +179,18 @@ class _CppTypeAstTemplate(_CppTypeAstNode):
         return f"{pyname}[{', '.join(args)}]", deps
 
 
+@dataclass
+class _CppTypeAstPointer(_CppTypeAstNode):
+    arg: _CppTypeAstName
+
+    def cppname(self) -> bytes:
+        return self.arg.cppname() + b"*"
+
+    def to_pytype(self) -> NameWithDependencies:
+        arg, deps = self.arg.to_pytype()
+        return f"Ref[{arg}]", deps
+
+
 def _template_args(stream: _TokenStream) -> tuple[_CppTypeAstNode, ...]:
     token = stream.next()
     args: tuple[_CppTypeAstNode, ...] = ()
@@ -131,10 +199,10 @@ def _template_args(stream: _TokenStream) -> tuple[_CppTypeAstNode, ...]:
         if not token:
             msg = "Unexpected end of stream"
             raise ValueError(msg)
-        if token[1] == b">":
+        if token.type == _TokenType.TEMPLATE_END:
             stream.next()
             break
-        if token[1] == b",":
+        if token.type == _TokenType.COMMA:
             stream.next()
             continue
         arg = _value(stream)
@@ -147,33 +215,56 @@ def _value(stream: _TokenStream) -> _CppTypeAstNode:
     if not token:
         msg = "Unexpected end of stream"
         raise ValueError(msg)
-    if token[1]:
+    if token.type != _TokenType.NAME:
         msg = f"Unexpected token {token}"
         raise ValueError(msg)
-    name = token[0]
+    name = token.value
     token = stream.peek()
-    if not token or token[1] in (b">", b","):
+    if not token or token.type in (
+        _TokenType.TEMPLATE_END,
+        _TokenType.COMMA,
+        _TokenType.POINTER,
+    ):
         # we are in a simple type
-        return _CppTypeAstNode(name)
-    if token[1] == b"<":
+        arg = _CppTypeAstName(name)
+        if token and token.type == _TokenType.POINTER:
+            # wrap arg in a pointer type
+            stream.next()
+            return _CppTypeAstPointer(arg)
+        return arg
+    if token.type == _TokenType.TEMPLATE_START:
         # we are in template rule
         return _CppTypeAstTemplate(name, _template_args(stream))
-    if not token[1]:
+    if token.type in (_TokenType.NAME, _TokenType.SPACE):
         # we are in typeid
-        while (token := stream.peek()) and not token[1]:
-            name += b" " + token[0]
+        while (token := stream.peek()) and token.type in (
+            _TokenType.NAME,
+            _TokenType.SPACE,
+        ):
+            name += token.value
             stream.next()
-        return _CppTypeAstNode(name)
+        return _CppTypeAstName(name)
     msg = f"Unexpected token {token}"
     raise ValueError(msg)
 
 
-def cpptype_to_pytype(cppname: bytes) -> tuple[str, set[str]]:
+def parse_cpptype(cppname: bytes) -> _CppTypeAstNode:
+    stream = _TokenStream(cppname)
+    return _value(stream)
+
+
+def normalize_cpptype(cppname: bytes) -> bytes:
+    """Normalize C++ type name
+    Any spaces in templates will be elided.
+    """
+    ast = parse_cpptype(cppname)
+    return ast.cppname()
+
+
+def cpptype_to_pytype(cppname: bytes) -> NameWithDependencies:
     """Convert C++ type name to Python type name.
 
     This uses a very simple parser that only handles the types we need.
     """
-    alltokens: list[_Token] = _tokenize.findall(cppname)
-    stream = _TokenStream(t for t in alltokens if t not in _ignored_terminals)
-    ast = _value(stream)
+    ast = parse_cpptype(cppname)
     return ast.to_pytype()

--- a/src/rootfilespec/cpptype.py
+++ b/src/rootfilespec/cpptype.py
@@ -96,6 +96,14 @@ class _CppTypeAstTemplate(_CppTypeAstNode):
         """Convert C++ type name to Python type name."""
         if self.name in _cpp_templates:
             pyname = _cpp_templates[self.name]
+        elif self.name == b"bitset":
+            argn, *rest = self.args
+            if rest:
+                msg = "bitset template has too many arguments"
+                raise ValueError(msg)
+            n = int(argn.name)
+            pyname = f"Annotated[int, StdBitset({n})]"
+            return pyname, set()
         else:
             msg = f"Template type {self.name!r} not implemented"
             raise NotImplementedError(msg)

--- a/src/rootfilespec/dispatch.py
+++ b/src/rootfilespec/dispatch.py
@@ -18,19 +18,6 @@ def normalize(s: bytes) -> str:
         .replace("<", "3c")
         .replace(">", "3e")
         .replace(",", "2c")
-        .replace(" ", "_")
+        .replace(" ", "20")
         .replace("*", "2a")
-    )
-
-
-def pyclass_to_cppname(pyclass: str) -> bytes:
-    """Convert the Python class name to a ROOT C++ class name."""
-    return (
-        pyclass.replace("*", "2a")
-        .replace(" ", "_")
-        .replace(",", "2c")
-        .replace(">", "3e")
-        .replace("<", "3c")
-        .replace(":", "3a")
-        .encode(ENCODING)
     )

--- a/src/rootfilespec/dispatch.py
+++ b/src/rootfilespec/dispatch.py
@@ -11,6 +11,7 @@ def normalize(s: bytes) -> str:
 
     This is used to generate the class name in the DICTIONARY.
     """
+    # TODO: #22 append version to all class names
     return (
         s.decode(ENCODING)
         .replace(":", "3a")

--- a/src/rootfilespec/dynamic.py
+++ b/src/rootfilespec/dynamic.py
@@ -20,7 +20,9 @@ from rootfilespec.container import (
     FixedSizeArray,
     StdVector,
     StdSet,
+    StdDeque,
     StdMap,
+    StdPair,
 )
 from rootfilespec.dispatch import DICTIONARY
 from rootfilespec.serializable import serializable

--- a/src/rootfilespec/dynamic.py
+++ b/src/rootfilespec/dynamic.py
@@ -1,3 +1,5 @@
+import warnings
+
 from rootfilespec import bootstrap
 from rootfilespec.bootstrap.TStreamerInfo import (
     ClassDef,
@@ -17,6 +19,8 @@ from rootfilespec.container import (
     BasicArray,
     FixedSizeArray,
     StdVector,
+    StdSet,
+    StdMap,
 )
 from rootfilespec.dispatch import DICTIONARY
 from rootfilespec.serializable import serializable
@@ -52,7 +56,7 @@ def streamerinfo_to_classes(streamerinfo: bootstrap.TList) -> str:
                 write(depdef)
             elif dep not in declared:
                 msg = f"Class {classdef.name} depends on {dep}, which is not declared"
-                raise ValueError(msg)
+                warnings.warn(msg, UserWarning, stacklevel=1)
         lines.append(classdef.code)
         declared.add(classdef.name)
 

--- a/src/rootfilespec/dynamic.py
+++ b/src/rootfilespec/dynamic.py
@@ -60,7 +60,7 @@ def streamerinfo_to_classes(streamerinfo: bootstrap.TList) -> str:
                 write(depdef)
             elif dep not in declared:
                 warning_log.append(
-                    f"Class {classdef.name} depends on {dep}, which is not declared"
+                    f"    Class {classdef.name} depends on {dep} which is missing"
                 )
                 lines.append(f"class {dep}(Uninterpreted):\n    pass\n")
         lines.append(classdef.code)
@@ -71,7 +71,10 @@ def streamerinfo_to_classes(streamerinfo: bootstrap.TList) -> str:
         write(classdef)
 
     # Write out the warnings
-    for msg in warning_log:
+    if warning_log:
+        msg = "Errors were found in the StreamerInfo:\n"
+        msg += "\n".join(warning_log)
+        msg += "\nThese members will be uninterpreted and skipped."
         warnings.warn(msg, UserWarning, stacklevel=2)
 
     return "\n".join(lines)

--- a/src/rootfilespec/dynamic.py
+++ b/src/rootfilespec/dynamic.py
@@ -24,7 +24,7 @@ from rootfilespec.container import (
 )
 from rootfilespec.dispatch import DICTIONARY
 from rootfilespec.serializable import serializable
-from rootfilespec.structutil import Fmt
+from rootfilespec.structutil import Fmt, StdBitset
 
 """
 

--- a/src/rootfilespec/dynamic.py
+++ b/src/rootfilespec/dynamic.py
@@ -61,9 +61,11 @@ def streamerinfo_to_classes(streamerinfo: bootstrap.TList) -> str:
             if depdef is not None:
                 write(depdef)
             elif dep not in declared:
-                warning_log.append(
-                    f"    Class {classdef.name} depends on {dep} which is missing"
-                )
+                if dep == classdef.name:
+                    msg = f"Class {classdef.name} depends on itself, which is not allowed (likely an unimplemented container type)"
+                else:
+                    msg = f"Class {classdef.name} depends on {dep} which is missing"
+                warning_log.append("    " + msg)
                 lines.append(
                     f"class {dep}(Uninterpreted):\n    pass\nDICTIONARY['{dep}'] = {dep}\n"
                 )

--- a/src/rootfilespec/dynamic.py
+++ b/src/rootfilespec/dynamic.py
@@ -64,7 +64,10 @@ def streamerinfo_to_classes(streamerinfo: bootstrap.TList) -> str:
                 warning_log.append(
                     f"    Class {classdef.name} depends on {dep} which is missing"
                 )
-                lines.append(f"class {dep}(Uninterpreted):\n    pass\n")
+                lines.append(
+                    f"class {dep}(Uninterpreted):\n    pass\nDICTIONARY['{dep}'] = {dep}\n"
+                )
+                declared.add(dep)
         lines.append(classdef.code)
         declared.add(classdef.name)
 

--- a/src/rootfilespec/serializable.py
+++ b/src/rootfilespec/serializable.py
@@ -41,7 +41,7 @@ class ROOTSerializable:
     """
 
     @classmethod
-    def read(cls: type[RT], buffer: ReadBuffer) -> tuple[RT, ReadBuffer]:
+    def read(cls, buffer: ReadBuffer):
         members: Members = {}
         # TODO: always loop through base classes? StreamedObject does this a special way
         members, buffer = cls.update_members(members, buffer)
@@ -66,7 +66,7 @@ class _ReadWrapper:
         return members, buffer
 
 
-class ContainerSerDe:
+class ContainerSerDe(ROOTSerializable):
     """A protocol for (De)serialization of generic container fields.
 
     The @serializable decorator will use these annotations to determine how to read
@@ -89,7 +89,7 @@ class ContainerSerDe:
         raise NotImplementedError(msg)
 
 
-class AssociativeContainerSerDe:
+class AssociativeContainerSerDe(ROOTSerializable):
     """A protocol for (De)serialization of generic associative container fields.
 
     The @serializable decorator will use these annotations to determine how to read

--- a/src/rootfilespec/serializable.py
+++ b/src/rootfilespec/serializable.py
@@ -27,11 +27,7 @@ def _get_annotations(cls: type) -> dict[str, Any]:
         from inspect import get_annotations
 
         return get_annotations(cls)
-    return {
-        field: ann
-        for field, ann in cls.__dict__.get("__annotations__", {}).items()
-        if not field.startswith("_") and field != "self"
-    }
+    return dict(cls.__dict__.get("__annotations__", {}).items())
 
 
 @dataclasses.dataclass

--- a/src/rootfilespec/serializable.py
+++ b/src/rootfilespec/serializable.py
@@ -4,7 +4,6 @@ from typing import (
     Annotated,
     Any,
     Callable,
-    Generic,
     TypeVar,
     get_args,
     get_origin,
@@ -15,10 +14,10 @@ from typing_extensions import dataclass_transform
 
 from rootfilespec.buffer import ReadBuffer
 
-T = TypeVar("T", bound="ROOTSerializable")
-OutType = TypeVar("OutType")
-Members = dict[str, Any]
-ReadObjMethod = Callable[[ReadBuffer], tuple[OutType, ReadBuffer]]
+RT = TypeVar("RT", bound="ROOTSerializable")
+MemberType = Any
+Members = dict[str, MemberType]
+ReadObjMethod = Callable[[ReadBuffer], tuple[MemberType, ReadBuffer]]
 ReadMembersMethod = Callable[[Members, ReadBuffer], tuple[Members, ReadBuffer]]
 
 
@@ -42,7 +41,7 @@ class ROOTSerializable:
     """
 
     @classmethod
-    def read(cls: type[T], buffer: ReadBuffer) -> tuple[T, ReadBuffer]:
+    def read(cls: type[RT], buffer: ReadBuffer) -> tuple[RT, ReadBuffer]:
         members: Members = {}
         # TODO: always loop through base classes? StreamedObject does this a special way
         members, buffer = cls.update_members(members, buffer)
@@ -67,7 +66,7 @@ class _ReadWrapper:
         return members, buffer
 
 
-class ContainerSerDe(Generic[OutType]):
+class ContainerSerDe:
     """A protocol for (De)serialization of generic container fields.
 
     The @serializable decorator will use these annotations to determine how to read
@@ -78,8 +77,29 @@ class ContainerSerDe(Generic[OutType]):
     """
 
     @classmethod
+    def build_reader(cls, fname: str, inner_reader: ReadObjMethod) -> ReadMembersMethod:
+        """Build a reader function for the given field name and inner read implementation.
+
+        The reader function should take a ReadBuffer and return a tuple of the new
+        arguments and the remaining buffer.
+        """
+        msg = f"Cannot build reader for {cls.__name__}"
+        raise NotImplementedError(msg)
+
+
+class AssociativeContainerSerDe:
+    """A protocol for (De)serialization of generic associative container fields.
+
+    The @serializable decorator will use these annotations to determine how to read
+    the field from the buffer. For example, if a dataclass has a field of type
+        `field: AssociativeContainer[KeyType, ValueType]`
+    Then `AssociativeContainerSerDe.build_reader(build_reader(KeyType), build_reader(ValueType))`
+    will be called to get a function that can read the field from the buffer.
+    """
+
+    @classmethod
     def build_reader(
-        cls, fname: str, inner_reader: ReadObjMethod[OutType]
+        cls, fname: str, key_reader: ReadObjMethod, value_reader: ReadObjMethod
     ) -> ReadMembersMethod:
         """Build a reader function for the given field name and inner read implementation.
 
@@ -110,29 +130,40 @@ class MemberSerDe:
         raise NotImplementedError(msg)
 
 
-def _get_read_method(fname: str, ftype: Any) -> ReadMembersMethod:
+def _build_read(ftype: type[MemberType]) -> ReadObjMethod:
+    membermethod = _build_update_members("", ftype)
+
+    def reader(buffer: ReadBuffer):
+        members, buffer = membermethod({}, buffer)
+        return ftype(**members), buffer
+
+    return reader
+
+
+def _build_update_members(fname: str, ftype: Any) -> ReadMembersMethod:
     if isinstance(ftype, type) and issubclass(ftype, ROOTSerializable):
         return _ReadWrapper(fname, ftype)
     if origin := get_origin(ftype):
         if origin is Annotated:
-            ftype, *annotations = get_args(ftype)
+            itype, *annotations = get_args(ftype)
             memberserde = next(
                 (ann for ann in annotations if isinstance(ann, MemberSerDe)), None
             )
             if memberserde:
-                return memberserde.build_reader(fname, ftype)
-            msg = f"Cannot read type {ftype} with annotations {annotations}"
+                return memberserde.build_reader(fname, itype)
+            msg = f"Cannot read type {itype} with annotations {annotations}"
             raise NotImplementedError(msg)
-        if issubclass(origin, ContainerSerDe):
-            ftype, *args = get_args(ftype)
-            assert not args  # TODO: will not work for std::pair
-            membermethod = _get_read_method("", ftype)
-
-            def inner_reader(buffer: ReadBuffer):
-                members, buffer = membermethod({}, buffer)
-                return ftype(**members), buffer
-
-            return origin.build_reader(fname, inner_reader)  # type: ignore[no-any-return]
+        if isinstance(origin, type) and issubclass(origin, ContainerSerDe):
+            itype, *args = get_args(ftype)
+            assert not args
+            item_reader = _build_read(itype)
+            return origin.build_reader(fname, item_reader)
+        if isinstance(origin, type) and issubclass(origin, AssociativeContainerSerDe):
+            ktype, vtype, *args = get_args(ftype)
+            assert not args
+            key_reader = _build_read(ktype)
+            value_reader = _build_read(vtype)
+            return origin.build_reader(fname, key_reader, value_reader)
         msg = f"Cannot read subscripted type {ftype} with origin {origin}"
         raise NotImplementedError(msg)
     msg = f"Cannot read type {ftype}"
@@ -140,7 +171,7 @@ def _get_read_method(fname: str, ftype: Any) -> ReadMembersMethod:
 
 
 @dataclass_transform()
-def serializable(cls: type[T]) -> type[T]:
+def serializable(cls: type[RT]) -> type[RT]:
     """A decorator to add a update_members method to a class that reads its fields from a buffer.
 
     The class must have type hints for its fields, and the fields must be of types that
@@ -161,14 +192,15 @@ def serializable(cls: type[T]) -> type[T]:
     localns = {cls.__name__: cls}
     namespace = get_type_hints(cls, localns=localns, include_extras=True)
     member_readers = [
-        _get_read_method(field, namespace[field]) for field in _get_annotations(cls)
+        _build_update_members(field, namespace[field])
+        for field in _get_annotations(cls)
     ]
 
     # TODO: scan through and coalesce the _FmtReader objects into a single function call
 
     @classmethod  # type: ignore[misc]
     def update_members(
-        _: type[T], members: Members, buffer: ReadBuffer
+        _: type[RT], members: Members, buffer: ReadBuffer
     ) -> tuple[Members, ReadBuffer]:
         for reader in member_readers:
             members, buffer = reader(members, buffer)

--- a/src/rootfilespec/structutil.py
+++ b/src/rootfilespec/structutil.py
@@ -29,3 +29,25 @@ class Fmt(MemberSerDe):
 
     def build_reader(self, fname: str, ftype: type):
         return _FmtReader(fname, self.fmt, ftype)
+
+
+@dataclasses.dataclass
+class StdBitset(MemberSerDe):
+    """A class to hold a std::bitset of a given size."""
+
+    size: int
+
+    def build_reader(self, fname: str, ftype: type):  # noqa: ARG002
+        # fmt = ">I"
+        # if self.size > 32:
+        #     fmt = ">Q"
+        # if self.size > 64:
+        #     msg = f"Unimplemented size {self.size}"
+        #     raise NotImplementedError(msg)
+
+        # return _FmtReader(fname, fmt, ftype)
+        def reader(members: Members, buffer: ReadBuffer) -> tuple[Members, ReadBuffer]:
+            msg = "StdBitset reader not implemented"
+            raise NotImplementedError(msg)
+
+        return reader

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -13,12 +13,23 @@ from rootfilespec.dynamic import streamerinfo_to_classes
 TESTABLE_FILES = [f for f in known_files if f.endswith(".root")]
 
 
-def _walk(dir: TDirectory, fetch_data: DataFetcher, depth=0, maxdepth=-1):
+def _walk(
+    dir: TDirectory,
+    fetch_data: DataFetcher,
+    failures: list[str],
+    *,
+    depth=0,
+    maxdepth=-1,
+):
     keylist = dir.get_KeyList(fetch_data)
     for item in keylist.values():
-        obj = item.read_object(fetch_data)
+        try:
+            obj = item.read_object(fetch_data)
+        except NotImplementedError as ex:
+            failures.append(str(ex))
+            continue
         if isinstance(obj, TDirectory) and (maxdepth < 0 or depth < maxdepth):
-            _walk(obj, fetch_data, depth + 1)
+            _walk(obj, fetch_data, failures, depth=depth + 1)
 
 
 @pytest.mark.parametrize("filename", TESTABLE_FILES)
@@ -43,11 +54,16 @@ def test_read_file(filename: str):
 
         rootdir = file.get_TFile(fetch_cached).rootdir
 
+        # List to collect NotImplementedError messages
+        failures: list[str] = []
+
         # Read all StreamerInfo (class definitions) from the file
         streamerinfo = file.get_StreamerInfo(fetch_data)
         if not streamerinfo:
             # Try to read all objects anyway
-            _walk(rootdir, fetch_data)
+            _walk(rootdir, fetch_data, failures)
+            if failures:
+                return pytest.xfail(reason=",".join(set(failures)))
             return None
 
         # Render the class definitions into python code
@@ -64,7 +80,9 @@ def test_read_file(filename: str):
             exec(classes, module.__dict__)
 
             # Read all objects from the file
-            return _walk(rootdir, fetch_data)
+            _walk(rootdir, fetch_data, failures)
+            if failures:
+                return pytest.xfail(reason=",".join(set(failures)))
         except NotImplementedError as ex:
             return pytest.xfail(reason=str(ex))
         finally:


### PR DESCRIPTION
Now we are at:
```
   3 - reason: Array length not implemented for TStreamerObject
   1 - reason: Array length not implemented for TStreamerObjectAny
  11 - reason: member_definition not implemented for TStreamerLoop
   3 - reason: Memberwise reading of StdVector not implemented
   2 - reason: RooRealVar not declared in the StreamerInfo, e.g. uproot-issue49.root
   2 - reason: Suspicious map with memberwise reading, incorrect length seen in uproot-issue465-flat.root
   2 - reason: Suspicious THx with fByteCount == 0 (e.g. uproot-issue-250.root)
   2 - reason: TDirectory.get_KeyList: fSeekKey is 0 0 (bad key but KeyList is valid, e.g. uproot-issue261.root)
   1 - reason: TKey.read_object: unknown type MGTRun
   1 - reason: TKey.read_object: unknown type StIOEvent
   1 - reason: TKey.read_object: unknown type TMatrixTSym3cdouble3e
   1 - reason: TKey.read_object: unknown type TTime,TKey.read_object: unknown type CalibrationCoefficient
   1 - reason: TLeafI not declared in StreamerInfo, e.g. uproot-issue413.root
   3 - reason: Unimplemented format double32
```