### PR TITLE
Memberwise streaming for some STL types

### DIFF
--- a/src/rootfilespec/bootstrap/TObject.py
+++ b/src/rootfilespec/bootstrap/TObject.py
@@ -48,6 +48,8 @@ class TObjFlag(IntFlag):
     """Appears in some TStreamerElement"""
     kDoNotDelete = 0x2000
     """TStreamerElement status bit or kInvalidObject"""
+    kListOfRules = 0x4000
+    """The schema evolution rules stored at the end of the streamer info"""
 
     # TODO: validate on initialization that no bits are set that are not defined in this class
     def __repr__(self):

--- a/src/rootfilespec/bootstrap/TStreamerInfo.py
+++ b/src/rootfilespec/bootstrap/TStreamerInfo.py
@@ -430,8 +430,12 @@ class TStreamerObjectPointer(TStreamerElement):
         if self.fArrayLength > 0:
             msg = f"Array length not implemented for {self.__class__.__name__}"
             raise NotImplementedError(msg)
-        assert self.fTypeName.fString.endswith(b"*")
-        typename, dependencies = cpptype_to_pytype(self.fTypeName.fString)
+        ctype = self.fTypeName.fString
+        if not ctype.endswith(b"*"):
+            # appears to happen when std::unique_ptr<T> is used
+            # e.g. RooRealVar's std::unique_ptr<RooAbsBinning> _binning (since v6-21-02)
+            ctype += b"*"
+        typename, dependencies = cpptype_to_pytype(ctype)
         this = parent.class_name()
         if this in dependencies:
             dependencies.remove(this)

--- a/src/rootfilespec/bootstrap/TStreamerInfo.py
+++ b/src/rootfilespec/bootstrap/TStreamerInfo.py
@@ -249,6 +249,7 @@ class ElementType(IntEnum):
 
     def as_fmt(self) -> str:
         """Get the format character for this element type."""
+        # TODO: just return Fmt() type
         fmtmap = {
             self.kChar: ">b",
             self.kShort: ">h",

--- a/src/rootfilespec/bootstrap/streamedobject.py
+++ b/src/rootfilespec/bootstrap/streamedobject.py
@@ -62,8 +62,6 @@ class StreamHeader(ROOTSerializable):
             if fVersion & _StreamConstants.kStreamedMemberwise:
                 fVersion &= ~_StreamConstants.kStreamedMemberwise
                 memberwise = True
-                msg = "Memberwise streaming not implemented"
-                raise NotImplementedError(msg)
             if fVersion == 0 and fByteCount >= 6:
                 # This class is versioned by its streamer checksum instead
                 (checksum,), buffer = buffer.unpack(">I")
@@ -206,6 +204,9 @@ def _auto_TObject_base(buffer) -> tuple[StreamHeader, ReadBuffer]:
         itemheader = StreamHeader(0, version, None, None, False)
     else:
         itemheader, buffer = StreamHeader.read(buffer)
+        if itemheader.memberwise:
+            msg = "Memberwise streaming not implemented for TObject base class"
+            raise NotImplementedError(msg)
     return itemheader, buffer
 
 

--- a/src/rootfilespec/bootstrap/streamedobject.py
+++ b/src/rootfilespec/bootstrap/streamedobject.py
@@ -108,6 +108,10 @@ class _RefReader:
 T = TypeVar("T", bound=MemberType)
 
 
+class Some:
+    """Placeholder to indicate the referred object exists"""
+
+
 class Ref(ContainerSerDe, Generic[T]):
     """A class to hold a reference to an object.
 
@@ -155,7 +159,7 @@ def read_streamed_item(
             return Ref(None), buffer
         # TODO: fetch the referenced object from the buffer.instance_refs
         _, buffer = buffer.consume(4)
-        return Ref(None), buffer
+        return Ref(Some()), buffer
     if itemheader.fClassName:
         clsname = normalize(itemheader.fClassName)
         if clsname not in DICTIONARY:

--- a/src/rootfilespec/bootstrap/streamedobject.py
+++ b/src/rootfilespec/bootstrap/streamedobject.py
@@ -63,6 +63,11 @@ class StreamHeader(ROOTSerializable):
             if fVersion & _StreamConstants.kStreamedMemberwise:
                 fVersion &= ~_StreamConstants.kStreamedMemberwise
                 memberwise = True
+                if fVersion != 9:
+                    # It seems all STL collections are v9?
+                    # These are the only ones we know how to read memberwise so far
+                    msg = f"Memberwise streaming not implemented for version {fVersion}"
+                    raise NotImplementedError(msg)
             if fVersion == 0 and fByteCount >= 6:
                 # This class is versioned by its streamer checksum instead
                 (checksum,), buffer = buffer.unpack(">I")

--- a/src/rootfilespec/serializable.py
+++ b/src/rootfilespec/serializable.py
@@ -15,7 +15,7 @@ from typing_extensions import dataclass_transform
 from rootfilespec.buffer import ReadBuffer
 
 RT = TypeVar("RT", bound="ROOTSerializable")
-MemberType = Any
+MemberType = Any  # Union[int, float, bytes, str, bool, "ROOTSerializable"]
 Members = dict[str, MemberType]
 ReadObjMethod = Callable[[ReadBuffer], tuple[MemberType, ReadBuffer]]
 ReadMembersMethod = Callable[[Members, ReadBuffer], tuple[Members, ReadBuffer]]

--- a/src/rootfilespec/serializable.py
+++ b/src/rootfilespec/serializable.py
@@ -17,7 +17,6 @@ from rootfilespec.buffer import ReadBuffer
 RT = TypeVar("RT", bound="ROOTSerializable")
 MemberType = Any  # Union[int, float, bytes, str, bool, "ROOTSerializable"]
 Members = dict[str, MemberType]
-ReadObjMethod = Callable[[ReadBuffer], tuple[MemberType, ReadBuffer]]
 ReadMembersMethod = Callable[[Members, ReadBuffer], tuple[Members, ReadBuffer]]
 
 
@@ -60,6 +59,21 @@ class _ReadWrapper:
         obj, buffer = self.objtype.read(buffer)
         members[self.fname] = obj
         return members, buffer
+
+
+@dataclasses.dataclass
+class ReadObjMethod:
+    """A wrapper to read a whole object from a buffer.
+
+    Some containers will inspect the member method to determine how to read the
+    object, for example, sometimes the StreamHeader will not be present
+    """
+
+    membermethod: ReadMembersMethod
+
+    def __call__(self, buffer: ReadBuffer) -> tuple[MemberType, ReadBuffer]:
+        members, buffer = self.membermethod({}, buffer)
+        return members[""], buffer
 
 
 class ContainerSerDe(ROOTSerializable):
@@ -124,18 +138,9 @@ class MemberSerDe:
         raise NotImplementedError(msg)
 
 
-@dataclasses.dataclass
-class _ObjectReader:
-    membermethod: ReadMembersMethod
-
-    def __call__(self, buffer: ReadBuffer) -> tuple[MemberType, ReadBuffer]:
-        members, buffer = self.membermethod({}, buffer)
-        return members[""], buffer
-
-
 def _build_read(ftype: type[MemberType]) -> ReadObjMethod:
     membermethod = _build_update_members("", ftype)
-    return _ObjectReader(membermethod)
+    return ReadObjMethod(membermethod)
 
 
 def _build_update_members(fname: str, ftype: Any) -> ReadMembersMethod:

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -35,11 +35,11 @@ def _walk(
         return
     keylist = dir.get_KeyList(fetch_data)
     for item in keylist.values():
+        itempath = path + b"/" + item.fName.fString
         try:
-            print(f"Reading {item.fName} of type {item.fClassName}")
             obj = item.read_object(fetch_data)
         except NotImplementedError as ex:
-            notimplemented_callback(path, ex)
+            notimplemented_callback(itempath, ex)
             continue
         if isinstance(obj, TDirectory) and (maxdepth < 0 or depth < maxdepth):
             _walk(
@@ -47,7 +47,7 @@ def _walk(
                 fetch_data,
                 notimplemented_callback,
                 depth=depth + 1,
-                path=path + b"/" + item.fName.fString,
+                path=itempath,
             )
         elif isinstance(obj, ROOT3a3aRNTuple):
             _walk_RNTuple(obj, fetch_data)
@@ -77,6 +77,7 @@ def test_read_file(filename: str):
 
         # List to collect NotImplementedError messages
         failures: list[str] = []
+
         def fail_cb(_: bytes, ex: NotImplementedError):
             print(f"NotImplementedError: {ex}")
             failures.append(str(ex))

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -1,6 +1,7 @@
 import sys
 import types
 from pathlib import Path
+from typing import Callable
 
 import pytest
 from skhep_testdata import data_path, known_files  # type: ignore[import-not-found]
@@ -23,10 +24,11 @@ def _walk_RNTuple(anchor: ROOT3a3aRNTuple, fetch_data: DataFetcher):
 def _walk(
     dir: TDirectory,
     fetch_data: DataFetcher,
-    failures: list[str],
+    notimplemented_callback: Callable[[bytes, NotImplementedError], None],
     *,
     depth=0,
     maxdepth=-1,
+    path=b"",
 ):
     if dir.fSeekKeys == 0:
         # empty directory
@@ -34,12 +36,19 @@ def _walk(
     keylist = dir.get_KeyList(fetch_data)
     for item in keylist.values():
         try:
+            print(f"Reading {item.fName} of type {item.fClassName}")
             obj = item.read_object(fetch_data)
         except NotImplementedError as ex:
-            failures.append(str(ex))
+            notimplemented_callback(path, ex)
             continue
         if isinstance(obj, TDirectory) and (maxdepth < 0 or depth < maxdepth):
-            _walk(obj, fetch_data, failures, depth=depth + 1)
+            _walk(
+                obj,
+                fetch_data,
+                notimplemented_callback,
+                depth=depth + 1,
+                path=path + b"/" + item.fName.fString,
+            )
         elif isinstance(obj, ROOT3a3aRNTuple):
             _walk_RNTuple(obj, fetch_data)
 
@@ -68,12 +77,15 @@ def test_read_file(filename: str):
 
         # List to collect NotImplementedError messages
         failures: list[str] = []
+        def fail_cb(_: bytes, ex: NotImplementedError):
+            print(f"NotImplementedError: {ex}")
+            failures.append(str(ex))
 
         # Read all StreamerInfo (class definitions) from the file
         streamerinfo = file.get_StreamerInfo(fetch_data)
         if not streamerinfo:
             # Try to read all objects anyway
-            _walk(rootdir, fetch_data, failures)
+            _walk(rootdir, fetch_data, fail_cb)
             if failures:
                 return pytest.xfail(reason=",".join(set(failures)))
             return None
@@ -92,7 +104,7 @@ def test_read_file(filename: str):
             exec(classes, module.__dict__)
 
             # Read all objects from the file
-            _walk(rootdir, fetch_data, failures)
+            _walk(rootdir, fetch_data, fail_cb)
             if failures:
                 return pytest.xfail(reason=",".join(set(failures)))
         except NotImplementedError as ex:


### PR DESCRIPTION
Allows to read 5 more test files!
Eventually we'll need to refactor the memberwise reading once it is more clear the pattern.