### PR TITLE
Migrate from DataFetcher to Locator pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,17 +52,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
+          enable-cache: true
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
 
       - name: Install package
-        run: python -m pip install .[test]
+        run: uv sync --group test
 
       - name: Test package
         run: >-
-          python -m pytest -ra --cov --cov-report=xml --cov-report=term
+          uv run pytest -ra --cov --cov-report=xml --cov-report=term
           --durations=20
 
       - name: Upload coverage report

--- a/docs/design.md
+++ b/docs/design.md
@@ -151,7 +151,7 @@ print(f"TFile at offset {loc.offset}, size {loc.size}")
 buffer = fetch_data(loc.offset, loc.size)
 
 # 3. Deserialize (locator knows the type)
-tfile = loc.read(buffer)
+tfile = loc.read_from(buffer)
 ```
 
 ### Batch Fetching Example
@@ -170,6 +170,6 @@ locators = [tfile_loc, si_loc] if si_loc else [tfile_loc]
 buffers = [fetch_data(loc.offset, loc.size) for loc in locators]
 
 # Deserialize all at once
-tfile = tfile_loc.read(buffers[0])
-streamerinfo = si_loc.read(buffers[1]) if si_loc else None
+tfile = tfile_loc.read_from(buffers[0])
+streamerinfo = si_loc.read_from(buffers[1]) if si_loc else None
 ```

--- a/docs/design.md
+++ b/docs/design.md
@@ -111,3 +111,65 @@ class TNamed(TObject):
 where the `@serializable` decorator takes care of the conversion between `str`
 and `TString`. In this library, we will prefer to use the second approach when
 feasible.
+
+## Data Fetching and Locators
+
+Many ROOT objects serve as references to data stored elsewhere in the file. For
+example, a `TKey` points to a serialized object, an `REnvelopeLink` points to an
+RNTuple envelope, and `TDirectory` points to a key list. To enable flexible I/O
+patterns (synchronous, asynchronous, or batch fetching), this library separates
+**data location** from **data fetching**.
+
+### The Locator Pattern
+
+The design follows this principle: **objects describe where data is; callers
+decide when and how to fetch it**.
+
+Each object that points to data provides a `*_locator` property that returns a
+specialized locator object. The locator has:
+
+- `offset: int` - byte offset in the file
+- `size: int` - size of the data to be read
+- `read_from(buffer) -> T` - deserializes the specific data type from the buffer
+
+### Specialized Locator Classes
+
+Even though `read_from` might appear to be implementable as `T.read(buffer)`,
+sometimes a locator points to some wrapper of the data. For example, a `TKey`
+points to the data prefixed by essentially another copy of itself, as a
+validation check. This method allows the locator to handle the unwrapping logic,
+and to return the correct type.
+
+### Usage Pattern
+
+```python
+# 1. Get the locator (no I/O)
+loc = root_file.tfile_locator
+print(f"TFile at offset {loc.offset}, size {loc.size}")
+
+# 2. Fetch the data (caller controls I/O)
+buffer = fetch_data(loc.offset, loc.size)
+
+# 3. Deserialize (locator knows the type)
+tfile = loc.read(buffer)
+```
+
+### Batch Fetching Example
+
+```python
+# Collect all locators first (no I/O)
+tfile_loc = root_file.tfile_locator
+si_loc = root_file.streamerinfo_locator
+locators = [tfile_loc, si_loc] if si_loc else [tfile_loc]
+
+# Batch fetch (optimization opportunity)
+# - Sort by offset for sequential reads
+# - Combine nearby reads
+# - Parallelize independent fetches
+# - Check cache before fetching
+buffers = [fetch_data(loc.offset, loc.size) for loc in locators]
+
+# Deserialize all at once
+tfile = tfile_loc.read(buffers[0])
+streamerinfo = si_loc.read(buffers[1]) if si_loc else None
+```

--- a/noxfile.py
+++ b/noxfile.py
@@ -38,7 +38,7 @@ def tests(session: nox.Session) -> None:
     """
     Run the unit and regular tests.
     """
-    session.install(".[test]")
+    session.install(".", "--group", "test")
     session.run("pytest", *session.posargs)
 
 
@@ -56,7 +56,8 @@ def docs(session: nox.Session) -> None:
     args, posargs = parser.parse_known_args(session.posargs)
     serve = args.builder == "html" and session.interactive
 
-    session.install("-e.[docs]", "sphinx-autobuild")
+    session.install("-e.", "--group", "docs")
+    session.install("sphinx-autobuild")
 
     shared_args = (
         "-n",  # nitpicky mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,16 +30,15 @@ classifiers = [
 dynamic = ["version"]
 dependencies = ["cramjam", "xxhash", "numpy", "typing_extensions"]
 
-[project.optional-dependencies]
+[dependency-groups]
 test = [
   "pytest >=6",
   "pytest-cov >=3",
   "scikit-hep-testdata",
 ]
 dev = [
-  "pytest >=6",
-  "pytest-cov >=3",
-  "scikit-hep-testdata",
+  { include-group = "test" },
+  "mypy",
 ]
 docs = [
   "sphinx>=7.0",
@@ -63,12 +62,6 @@ build.hooks.vcs.version-file = "src/rootfilespec/_version.py"
 [tool.hatch.envs.default]
 features = ["test"]
 scripts.test = "pytest {args}"
-
-
-[tool.uv]
-dev-dependencies = [
-  "rootfilespec[test]",
-]
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,9 @@ module = "rootfilespec.*"
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
 
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_any_generics = false
 
 
 [tool.ruff.lint]

--- a/src/rootfilespec/bootstrap/RAnchor.py
+++ b/src/rootfilespec/bootstrap/RAnchor.py
@@ -1,11 +1,17 @@
+from collections.abc import Callable
 from typing import Annotated
 
 from rootfilespec.bootstrap.streamedobject import StreamedObject
-from rootfilespec.rntuple.envelope import REnvelopeLink
+from rootfilespec.rntuple.envelope import REnvelopeLocator
 from rootfilespec.rntuple.footer import FooterEnvelope
 from rootfilespec.rntuple.header import HeaderEnvelope
 from rootfilespec.rntuple.RLocator import LargeLocator
-from rootfilespec.serializable import DataFetcher, serializable
+from rootfilespec.serializable import (
+    Locator,
+    ReadBuffer,
+    ROOTSerializable,
+    serializable,
+)
 from rootfilespec.structutil import Fmt
 
 
@@ -23,18 +29,36 @@ class ROOT3a3aRNTuple(StreamedObject):
     fLenFooter: Annotated[int, Fmt(">Q")]
     fMaxKeySize: Annotated[int, Fmt(">Q")]
 
-    def get_header(self, fetch_data: DataFetcher) -> HeaderEnvelope:
+    @property
+    def header_locator(self) -> REnvelopeLocator[HeaderEnvelope]:
+        """Get a locator for the RNTuple Header Envelope."""
+        return REnvelopeLocator(
+            self.fLenHeader,
+            LargeLocator(self.fNBytesHeader, self.fSeekHeader),
+            HeaderEnvelope,
+        )
+
+    @property
+    def footer_locator(self) -> REnvelopeLocator[FooterEnvelope]:
+        """Get a locator for the RNTuple Footer Envelope."""
+        return REnvelopeLocator(
+            self.fLenFooter,
+            LargeLocator(self.fNBytesFooter, self.fSeekFooter),
+            FooterEnvelope,
+        )
+
+    def get_header(
+        self, fetch_data: Callable[[Locator[ROOTSerializable]], ReadBuffer]
+    ) -> HeaderEnvelope:
         """Reads the RNTuple Header Envelope from the given buffer."""
-        headerLink = REnvelopeLink(
-            self.fLenHeader, LargeLocator(self.fNBytesHeader, self.fSeekHeader)
-        )
+        loc = self.header_locator
+        buffer = fetch_data(loc)
+        return loc.read_from(buffer)
 
-        return headerLink.read_envelope(fetch_data, HeaderEnvelope)
-
-    def get_footer(self, fetch_data: DataFetcher) -> FooterEnvelope:
+    def get_footer(
+        self, fetch_data: Callable[[Locator[ROOTSerializable]], ReadBuffer]
+    ) -> FooterEnvelope:
         """Reads the RNTuple Footer Envelope from the given buffer."""
-        footerLink = REnvelopeLink(
-            self.fLenFooter, LargeLocator(self.fNBytesFooter, self.fSeekFooter)
-        )
-
-        return footerLink.read_envelope(fetch_data, FooterEnvelope)
+        loc = self.footer_locator
+        buffer = fetch_data(loc)
+        return loc.read_from(buffer)

--- a/src/rootfilespec/bootstrap/TDirectory.py
+++ b/src/rootfilespec/bootstrap/TDirectory.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Annotated
 
 from rootfilespec.bootstrap.TDatime import TDatime, TDatime_to_datetime
-from rootfilespec.bootstrap.TKey import TKey
+from rootfilespec.bootstrap.TKey import TKey, TypedTKey
 from rootfilespec.bootstrap.TUUID import TUUID
 from rootfilespec.serializable import (
     DataFetcher,
@@ -104,19 +107,20 @@ class TDirectory(ROOTSerializable):
         return members, buffer
 
     def get_KeyList(self, fetch_data: DataFetcher):
-        buffer = fetch_data(
-            self.fSeekKeys, self.header.fNbytesName + self.header.fNbytesKeys
-        )
+        buffer = fetch_data(self.fSeekKeys, self.header.fNbytesKeys)
 
         key, _ = TKey.read(buffer)
         if key.fSeekKey == 0:
-            msg = f"TDirectory.get_KeyList: fSeekKey is 0 {key.fSeekKey} (bad key but KeyList is valid, e.g. uproot-issue261.root)"
+            msg = f"fSeekKey is 0 {key.fSeekKey} (bad key but KeyList is valid, e.g. uproot-issue261.root)"
             raise NotImplementedError(msg)
         if key.fSeekKey != self.fSeekKeys:
-            msg = f"TDirectory.read_keylist: fSeekKey mismatch {key.fSeekKey} != {self.fSeekKeys}"
+            msg = f"fSeekKey mismatch {key.fSeekKey} != {self.fSeekKeys}"
+            raise ValueError(msg)
+        if key.header.fNbytes != self.header.fNbytesKeys:
+            msg = f"fNbytes mismatch {key.header.fNbytes} != {self.header.fNbytesKeys}"
             raise ValueError(msg)
         if key.fSeekPdir != self.fSeekDir:
-            msg = f"TDirectory.read_keylist: fSeekPdir mismatch {key.fSeekPdir} != {self.fSeekDir}"
+            msg = f"fSeekPdir mismatch {key.fSeekPdir} != {self.fSeekDir}"
             raise ValueError(msg)
 
         def fetch_cached(seek: int, size: int):
@@ -127,6 +131,35 @@ class TDirectory(ROOTSerializable):
             raise ValueError(msg)
 
         return key.read_object(fetch_cached, objtype=TKeyList)
+
+    @property
+    def keylist_locator(self) -> KeyListLocator:
+        return KeyListLocator(
+            offset=self.fSeekKeys,
+            size=self.header.fNbytesKeys,
+            parent_offset=self.fSeekDir,
+        )
+
+
+@dataclass(frozen=True)
+class KeyListLocator:
+    offset: int
+    size: int
+    parent_offset: int
+
+    def read_from(self, buffer: ReadBuffer) -> TypedTKey[TKeyList]:
+        key, _ = TKey.read(buffer)
+        if key.fSeekKey == 0:
+            msg = f"fSeekKey is 0 {key.fSeekKey} (bad key but KeyList is valid, e.g. uproot-issue261.root)"
+            # note: fSeekPdir will also be 0, this is when there is no streamerinfo for the file
+            raise NotImplementedError(msg)
+        if key.fSeekKey != self.offset:
+            msg = f"fSeekKey mismatch {key.fSeekKey} != {self.offset}"
+            raise ValueError(msg)
+        if key.fSeekPdir != self.parent_offset:
+            msg = f"Parent offset mismatch {key.fSeekPdir} != {self.parent_offset}"
+            raise ValueError(msg)
+        return TypedTKey(key, TKeyList)
 
 
 # TODO: are these different? Both are encountered

--- a/src/rootfilespec/bootstrap/TFile.py
+++ b/src/rootfilespec/bootstrap/TFile.py
@@ -169,7 +169,7 @@ class ROOTFile(ROOTSerializable):
         elif not fVersion.large:
             header, buffer = ROOTFile_header_v622_small.read(buffer)  # type: ignore[assignment]
         else:
-            header, buffer = ROOTFile_header_v622_small.read(buffer)  # type: ignore[assignment]
+            header, buffer = ROOTFile_header_v622_large.read(buffer)  # type: ignore[assignment]
         padding, buffer = buffer.consume(header.fBEGIN - buffer.relpos)
         members["magic"] = magic
         members["fVersion"] = fVersion

--- a/src/rootfilespec/bootstrap/TFile.py
+++ b/src/rootfilespec/bootstrap/TFile.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Annotated
 
 from rootfilespec.bootstrap.strings import TString
 from rootfilespec.bootstrap.TDirectory import TDirectory
-from rootfilespec.bootstrap.TKey import TKey
+from rootfilespec.bootstrap.TKey import TKey, TypedTKey
 from rootfilespec.bootstrap.TList import TList
 from rootfilespec.bootstrap.TUUID import TUUID
 from rootfilespec.serializable import (
@@ -165,9 +167,9 @@ class ROOTFile(ROOTSerializable):
         if fVersion <= VersionInfo(6, 2, 2):
             header, buffer = ROOTFile_header_v302.read(buffer)
         elif not fVersion.large:
-            header, buffer = ROOTFile_header_v622_small.read(buffer)
+            header, buffer = ROOTFile_header_v622_small.read(buffer)  # type: ignore[assignment]
         else:
-            header, buffer = ROOTFile_header_v622_large.read(buffer)
+            header, buffer = ROOTFile_header_v622_small.read(buffer)  # type: ignore[assignment]
         padding, buffer = buffer.consume(header.fBEGIN - buffer.relpos)
         members["magic"] = magic
         members["fVersion"] = fVersion
@@ -175,17 +177,29 @@ class ROOTFile(ROOTSerializable):
         members["padding"] = padding
         return members, buffer
 
+    @property
+    def tfile_locator(self) -> TFileLocator:
+        """Get a locator for the TFile object (root directory) in the file."""
+        return TFileLocator(self.header.fBEGIN, self.header.fNbytesName)
+
     def get_TFile(self, fetch_data: DataFetcher):
         """Get the TFile object (root directory) from the file."""
         buffer = fetch_data(self.header.fBEGIN, self.header.fNbytesName)
         key, buffer = TKey.read(buffer)
         if key.fSeekKey != self.header.fBEGIN:
-            msg = f"ROOTFile.read_rootkey: key.fSeekKey != self.header.fBEGIN: {key.fSeekKey} != {self.header.fBEGIN}"
+            msg = f"key.fSeekKey != self.header.fBEGIN: {key.fSeekKey} != {self.header.fBEGIN}"
             raise ValueError(msg)
         if key.fSeekPdir != 0:
-            msg = f"ROOTFile.read_rootkey: key.fSeekPdir != 0: {key.fSeekPdir} != 0"
+            msg = f"key.fSeekPdir != 0: {key.fSeekPdir} != 0"
             raise ValueError(msg)
         return key.read_object(fetch_data, objtype=TFile)
+
+    @property
+    def streamerinfo_locator(self) -> StreamerInfoLocator | None:
+        """Get a locator for the StreamerInfo record in the file, if it exists."""
+        if self.header.fNbytesInfo == 0:
+            return None
+        return StreamerInfoLocator(self.header.fSeekInfo, self.header.fNbytesInfo)
 
     def get_StreamerInfo(self, fetch_data: DataFetcher):
         if self.header.fNbytesInfo == 0:
@@ -206,6 +220,31 @@ class ROOTFile(ROOTSerializable):
         return key.read_object(fetch_cached, objtype=TList)
 
 
+@dataclass(frozen=True)
+class InitialReadLocator:
+    """Locator for the initial read of the ROOT file"""
+
+    initial_read_size: int = 512
+    """Suggested size to read for the initial information of the ROOT file.
+
+    This is a size hint for some initial information, including the ROOTFile
+    header and TFile key+object, but not necessarily the StreamerInfo.
+    """
+
+    @property
+    def offset(self) -> int:
+        return 0
+
+    @property
+    def size(self) -> int:
+        return self.initial_read_size
+
+    def read_from(self, buffer: ReadBuffer) -> ROOTFile:
+        """Read the ROOTFile object from the given buffer."""
+        file, _ = ROOTFile.read(buffer)
+        return file
+
+
 @serializable
 class TFile(ROOTSerializable):
     """The TFile object is a TDirectory with an extra name and title field (the first or "root" TDirectory):
@@ -223,3 +262,48 @@ class TFile(ROOTSerializable):
 
     def get_KeyList(self, fetch_data):
         return self.rootdir.get_KeyList(fetch_data)
+
+
+@dataclass(frozen=True)
+class TFileLocator:
+    """Locator for the TFile object in the ROOT file."""
+
+    offset: int
+    size: int
+
+    def read_from(self, buffer: ReadBuffer):
+        """Read the TFile object from the given buffer."""
+        key, buffer = TKey.read(buffer)
+        if key.fSeekKey != self.offset:
+            msg = f"Key's reported position does not match location: {key.fSeekKey} != {self.offset}"
+            raise ValueError(msg)
+        if key.fSeekPdir != 0:
+            msg = f"Key's parent directory is not the root directory: {key.fSeekPdir}"
+            raise ValueError(msg)
+
+        return TypedTKey(key, TFile)
+
+
+@dataclass(frozen=True)
+class StreamerInfoLocator:
+    """Locator for the StreamerInfo record in the ROOT file."""
+
+    offset: int
+    size: int
+
+    def read_from(self, buffer: ReadBuffer):
+        """Read the StreamerInfo TList object from the given buffer.
+
+        The StreamerInfo record is a TList prepended as usual by a TKey, but
+        abnormally, the TKey that would be used to read this is itself
+        the prepended TKey.  So we read both from the one buffer.
+        """
+        key, buffer = TKey.read(buffer)
+        if key.fSeekKey != self.offset:
+            msg = f"Key's reported position does not match location: {key.fSeekKey} != {self.offset}"
+            raise ValueError(msg)
+        if key.header.fNbytes != self.size:
+            msg = f"Key's reported size does not match location: {key.header.fNbytes} != {self.size}"
+            raise ValueError(msg)
+
+        return TypedTKey(key, TList)

--- a/src/rootfilespec/bootstrap/TKey.py
+++ b/src/rootfilespec/bootstrap/TKey.py
@@ -1,11 +1,11 @@
-from typing import Annotated, TypeVar, overload
+from dataclasses import dataclass
+from typing import Annotated, Generic, TypeVar, overload
 
-from rootfilespec.bootstrap.compression import RCompressed
+from rootfilespec.bootstrap.compression import decompress
 from rootfilespec.bootstrap.strings import TString
 from rootfilespec.bootstrap.TDatime import TDatime, TDatime_to_datetime
 from rootfilespec.dispatch import normalize
 from rootfilespec.serializable import (
-    BufferContext,
     DataFetcher,
     Members,
     ReadBuffer,
@@ -115,27 +115,14 @@ class TKey(ROOTSerializable):
         # The length of the buffer is the number of bytes of compressed data
         if len(buffer) != self.header.fObjlen:
             # This is a compressed object
-            compressed, buffer = RCompressed.read(buffer)
-            if compressed.uncompressed_size() != self.header.fObjlen:
-                msg = "TKey.read_object: uncompressed size mismatch. "
-                msg += f"{compressed.uncompressed_size()} != {self.header.fObjlen}"
-                raise ValueError(msg)
-            if buffer:
-                msg = f"TKey.read_object: buffer not empty after reading compressed object. {buffer=}"
-                raise ValueError(msg)
-            buffer = ReadBuffer(
-                compressed.decompress(),
-                relpos=self.header.fKeylen,
-                file_context=buffer.file_context,
-                context=BufferContext(abspos=None),
-            )
+            buffer = decompress(buffer, self.header.fObjlen)
         if objtype is not None:
             typename = objtype.__name__
             obj, buffer = objtype.read(buffer)
         else:
             typename = normalize(self.fClassName.fString)
             dyntype = buffer.file_context.type_by_name(typename)
-            obj, buffer = dyntype.read(buffer)
+            obj, buffer = dyntype.read(buffer)  # type: ignore[assignment]
         # Some types we have to handle trailing bytes
         if typename == "TKeyList":
             # TODO: understand this padding
@@ -153,5 +140,41 @@ class TKey(ROOTSerializable):
             msg += f"\n{obj=}"
             msg += f"\nBuffer: {buffer}"
             raise ValueError(msg)
-        # mypy doesn't understand that we have obj: ObjType | ROOTSerializable here
-        return obj  # type: ignore[no-any-return]
+        return obj
+
+    @property
+    def offset(self) -> int:
+        return self.fSeekKey
+
+    @property
+    def size(self) -> int:
+        return self.header.fNbytes
+
+    def read_from(self, buffer: ReadBuffer) -> ROOTSerializable:
+        return self.read_object(lambda _seek, _size: buffer)
+
+
+@dataclass(frozen=True)
+class TypedTKey(Generic[ObjType], ROOTSerializable):
+    """A TKey with a specified object type."""
+
+    key: TKey
+    objtype: type[ObjType]
+
+    @property
+    def offset(self) -> int:
+        return self.key.offset
+
+    @property
+    def size(self) -> int:
+        return self.key.size
+
+    @classmethod
+    def read(cls, buffer: ReadBuffer):
+        key, buffer = TKey.read(buffer)
+        typename = normalize(key.fClassName.fString)
+        objtype = buffer.file_context.type_by_name(typename)
+        return cls(key=key, objtype=objtype), buffer  # type: ignore[arg-type]
+
+    def read_from(self, buffer: ReadBuffer) -> ObjType:
+        return self.key.read_object(lambda _seek, _size: buffer, objtype=self.objtype)

--- a/src/rootfilespec/bootstrap/compression.py
+++ b/src/rootfilespec/bootstrap/compression.py
@@ -157,7 +157,7 @@ class RCompressed(ROOTSerializable):
     def uncompressed_size(self) -> int:
         return sum(chunk.header.uncompressed_size() for chunk in self.chunks)
 
-    def decompress(self) -> memoryview[int]:
+    def decompress(self) -> memoryview:
         out = memoryview(bytearray(self.uncompressed_size()))
         start = 0
         for chunk in self.chunks:

--- a/src/rootfilespec/bootstrap/compression.py
+++ b/src/rootfilespec/bootstrap/compression.py
@@ -5,6 +5,7 @@ from typing import Annotated, Protocol
 import cramjam  # type: ignore[import-not-found]
 
 from rootfilespec.serializable import (
+    BufferContext,
     Members,
     MemberSerDe,
     ReadBuffer,
@@ -156,7 +157,7 @@ class RCompressed(ROOTSerializable):
     def uncompressed_size(self) -> int:
         return sum(chunk.header.uncompressed_size() for chunk in self.chunks)
 
-    def decompress(self):
+    def decompress(self) -> memoryview[int]:
         out = memoryview(bytearray(self.uncompressed_size()))
         start = 0
         for chunk in self.chunks:
@@ -227,3 +228,22 @@ class RCompressionSettings(ROOTSerializable):
     def level(self) -> int:
         """Get the compression level used for this column."""
         return self.compressionsettings % 100
+
+
+def decompress(buffer: ReadBuffer, expected_size: int) -> ReadBuffer:
+    """Decompress a data payload from the given buffer."""
+    relpos = buffer.relpos
+    compressed, buffer = RCompressed.read(buffer)
+    if compressed.uncompressed_size() != expected_size:
+        msg = "Decompressed size mismatch. "
+        msg += f"{compressed.uncompressed_size()} != {expected_size}"
+        raise ValueError(msg)
+    if buffer:
+        msg = f"Expected buffer to be empty after reading compressed data, but got\n{buffer}"
+        raise ValueError(msg)
+    return ReadBuffer(
+        compressed.decompress(),
+        relpos=relpos,
+        file_context=buffer.file_context,
+        context=BufferContext(abspos=None),
+    )

--- a/src/rootfilespec/rntuple/RLocator.py
+++ b/src/rootfilespec/rntuple/RLocator.py
@@ -1,15 +1,16 @@
 from dataclasses import dataclass
 
-from rootfilespec.serializable import DataFetcher, ReadBuffer, ROOTSerializable
+from rootfilespec.serializable import ReadBuffer, ROOTSerializable
 
 
 @dataclass
 class RLocator(ROOTSerializable):
-    """A base class representing a Locator for RNTuples.
-    A locator is a generalized way to specify a certain byte range on the storage medium.
-        For disk-based storage, the locator is just byte offset and byte size.
-        For other storage systems, the locator contains enough information to retrieve the referenced block,
-            e.g. in object stores, the locator can specify a certain object ID.
+    """A base class representing an RNTuple locator data structure.
+
+    An RLocator is a generalized way to specify a certain byte range on the storage medium.
+    For disk-based storage, the locator contains byte offset and byte size.
+    For other storage systems, the locator contains enough information to retrieve the referenced block,
+    e.g. in object stores, the locator can specify a certain object ID.
 
     All locators begin with a signed 32 bit integer.
     If the integer is positive, the locator is a standard locator.
@@ -18,11 +19,13 @@ class RLocator(ROOTSerializable):
     Size and type mean different things for standard and non-standard locators.
 
     This base class checks the type of the locator and reads the appropriate subclass.
-    It contains a `get_buffer()` method that should be implemented by subclasses to return the buffer for the envelope.
-    This provides forward compatibility for different locator types, as the envelope can be read using the same method.
 
-    All Envelope Links will have a Locator, but a Locator doesn't require an Envelope Link.
-    (See the Page Location in the Page List Envelopes for an example of a Locator without an Envelope Link.)
+    All Envelope Links will have an RLocator, but an RLocator doesn't require an Envelope Link.
+    (See the Page Location in the Page List Envelopes for an example of an RLocator without an Envelope Link.)
+
+    Note: RLocator itself is just a data structure holding offset/size information.
+    It is used as a building block by full locators like REnvelopeLocator and RPageDescription,
+    which implement the Locator protocol with offset, size, and read_from() methods.
     """
 
     size: int
@@ -70,11 +73,6 @@ class RLocator(ROOTSerializable):
         msg = f"Unknown non-standard locator type: {locatorType=}"
         raise ValueError(msg)
 
-    def get_buffer(self, fetch_data: DataFetcher):
-        """This should be overridden by subclasses"""
-        msg = "get_buffer() not implemented for this locator type"
-        raise NotImplementedError(msg)
-
 
 @dataclass
 class StandardLocator(RLocator):
@@ -99,10 +97,6 @@ class StandardLocator(RLocator):
 
         return cls(size, offset), buffer
 
-    def get_buffer(self, fetch_data: DataFetcher):
-        """Returns the buffer for the byte range specified by the standard locator."""
-        return fetch_data(self.offset, self.size)
-
 
 @dataclass
 class LargeLocator(RLocator):
@@ -125,7 +119,3 @@ class LargeLocator(RLocator):
         (offset,), buffer = buffer.unpack("<Q")
 
         return cls(size, offset), buffer
-
-    def get_buffer(self, fetch_data: DataFetcher):
-        """Returns the buffer for the byte range specified by the "Large Locator" payload."""
-        return fetch_data(self.offset, self.size)

--- a/src/rootfilespec/rntuple/RNTuple.py
+++ b/src/rootfilespec/rntuple/RNTuple.py
@@ -1,4 +1,5 @@
 import dataclasses
+from collections.abc import Callable
 from math import ceil
 
 from rootfilespec.bootstrap.RAnchor import ROOT3a3aRNTuple
@@ -14,7 +15,7 @@ from rootfilespec.rntuple.schema import (
     ExtraTypeInformation,
     FieldDescription,
 )
-from rootfilespec.serializable import DataFetcher
+from rootfilespec.serializable import Locator, ReadBuffer, ROOTSerializable
 
 
 @dataclasses.dataclass
@@ -93,7 +94,11 @@ class RNTuple:
     pagelistEnvelopes: list[PageListEnvelope]
 
     @classmethod
-    def from_anchor(cls, anchor: ROOT3a3aRNTuple, fetch_data: DataFetcher) -> "RNTuple":
+    def from_anchor(
+        cls,
+        anchor: ROOT3a3aRNTuple,
+        fetch_data: Callable[[Locator[ROOTSerializable]], ReadBuffer],
+    ) -> "RNTuple":
         """Reads the RNTuple from the given anchor."""
         headerEnvelope = anchor.get_header(fetch_data)
         footerEnvelope = anchor.get_footer(fetch_data)

--- a/src/rootfilespec/rntuple/envelope.py
+++ b/src/rootfilespec/rntuple/envelope.py
@@ -1,12 +1,13 @@
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Annotated, TypeVar
+from typing import Annotated, Generic, TypeVar, cast
 
 from typing_extensions import Self
 
 from rootfilespec.bootstrap.compression import decompress
 from rootfilespec.rntuple.RLocator import RLocator
 from rootfilespec.serializable import (
-    DataFetcher,
+    Locator,
     Members,
     ReadBuffer,
     ROOTSerializable,
@@ -116,16 +117,62 @@ class REnvelope(ROOTSerializable):
 EnvType = TypeVar("EnvType", bound=REnvelope)
 
 
+@dataclass(frozen=True)
+class REnvelopeLocator(Generic[EnvType]):
+    """A locator for an RNTuple Envelope.
+
+    This follows the locator pattern: it describes where an envelope is located
+    and how to deserialize it, but the caller controls when/how to fetch the data.
+    """
+
+    length: int
+    """The uncompressed length of the envelope."""
+    locator: RLocator
+    """The locator for the envelope (offset and size)."""
+    envtype: type[EnvType]
+    """The envelope type to deserialize."""
+
+    @property
+    def offset(self) -> int:
+        """The byte offset of the envelope in the file."""
+        # Note: self.locator is always StandardLocator or LargeLocator at runtime,
+        # which have offset fields. Cast needed because base RLocator doesn't have offset.
+        return cast(Locator[ROOTSerializable], self.locator).offset
+
+    @property
+    def size(self) -> int:
+        """The (compressed) size of the envelope data."""
+        return self.locator.size
+
+    def read_from(self, buffer: ReadBuffer) -> EnvType:
+        """Read the envelope from the given buffer.
+
+        Envelopes are compressed, so this decompresses and deserializes.
+        """
+        #### Decompress the buffer if necessary
+        if len(buffer) != self.length:
+            buffer = decompress(buffer, self.length)
+
+        #### Now read the envelope
+        envelope, buffer = self.envtype.read(buffer)
+
+        if buffer:
+            msg = "REnvelopeLocator.read_from: buffer not empty after reading envelope."
+            raise ValueError(msg)
+
+        return envelope
+
+
 @serializable
 class REnvelopeLink(ROOTSerializable):
     """A class representing the RNTuple Envelope Link (somewhat analogous to a TKey).
+
     An Envelope Link references an Envelope in an RNTuple.
-    An Envelope Link is consists of a 64 bit unsigned integer that specifies the
-        uncompressed size (i.e. length) of the envelope, followed by a Locator.
+    An Envelope Link consists of a 64 bit unsigned integer that specifies the
+    uncompressed size (i.e. length) of the envelope, followed by a Locator.
 
     Envelope Links of this form (currently seem to be) only used to locate Page List Envelopes.
     The Header Envelope and Footer Envelope are located using the information in the RNTuple Anchor.
-    The Header and Footer Envelope Links are created in the RNTuple Anchor class by casting directly to this class.
     """
 
     length: Annotated[int, Fmt("<Q")]
@@ -133,33 +180,16 @@ class REnvelopeLink(ROOTSerializable):
     locator: RLocator
     """The locator for the envelope."""
 
+    def envelope_locator(self, envtype: type[EnvType]) -> REnvelopeLocator[EnvType]:
+        """Get a locator for the envelope."""
+        return REnvelopeLocator(self.length, self.locator, envtype)
+
     def read_envelope(
         self,
-        fetch_data: DataFetcher,
+        fetch_data: Callable[[Locator[ROOTSerializable]], ReadBuffer],
         envtype: type[EnvType],
     ) -> EnvType:
-        """Reads an REnvelope from the given buffer."""
-        #### Load the (possibly compressed) envelope into the buffer
-        buffer = self.locator.get_buffer(fetch_data)
-
-        #### If compressed, decompress the envelope
-        # The length of the buffer is the number of bytes of compressed data
-        if len(buffer) != self.length:
-            # This is a compressed object
-            buffer = decompress(buffer, self.length)
-        # Now the envelope is uncompressed
-
-        #### Read the envelope
-        envelope, buffer = envtype.read(buffer)
-
-        #### Check that buffer is empty
-        if buffer:
-            msg = (
-                "REnvelopeLink.read_envelope: buffer not empty after reading envelope."
-            )
-            msg += f"\n{self=}"
-            msg += f"\n{envelope=}"
-            msg += f"\nBuffer: {buffer}"
-            raise ValueError(msg)
-
-        return envelope
+        """Reads the Envelope from the given data source using the locator."""
+        loc = self.envelope_locator(envtype)
+        buffer = fetch_data(loc)
+        return loc.read_from(buffer)

--- a/src/rootfilespec/rntuple/envelope.py
+++ b/src/rootfilespec/rntuple/envelope.py
@@ -3,10 +3,9 @@ from typing import Annotated, TypeVar
 
 from typing_extensions import Self
 
-from rootfilespec.bootstrap.compression import RCompressed
+from rootfilespec.bootstrap.compression import decompress
 from rootfilespec.rntuple.RLocator import RLocator
 from rootfilespec.serializable import (
-    BufferContext,
     DataFetcher,
     Members,
     ReadBuffer,
@@ -147,20 +146,7 @@ class REnvelopeLink(ROOTSerializable):
         # The length of the buffer is the number of bytes of compressed data
         if len(buffer) != self.length:
             # This is a compressed object
-            compressed, buffer = RCompressed.read(buffer)
-            if compressed.uncompressed_size() != self.length:
-                msg = "REnvelopeLink.read_envelope: uncompressed size mismatch. "
-                msg += f"{compressed.uncompressed_size()} != {self.length}"
-                raise ValueError(msg)
-            if buffer:
-                msg = f"REnvelopeLink.read_envelope: buffer not empty after reading compressed object. {buffer=}"
-                raise ValueError(msg)
-            buffer = ReadBuffer(
-                compressed.decompress(),
-                relpos=self.length,
-                file_context=buffer.file_context,
-                context=BufferContext(abspos=None),
-            )
+            buffer = decompress(buffer, self.length)
         # Now the envelope is uncompressed
 
         #### Read the envelope

--- a/src/rootfilespec/rntuple/footer.py
+++ b/src/rootfilespec/rntuple/footer.py
@@ -1,9 +1,11 @@
+from collections.abc import Callable
 from typing import Annotated
 
 from rootfilespec.rntuple.envelope import (
     ENVELOPE_TYPE_MAP,
     REnvelope,
     REnvelopeLink,
+    REnvelopeLocator,
     RFeatureFlags,
 )
 from rootfilespec.rntuple.pagelist import PageListEnvelope
@@ -14,7 +16,12 @@ from rootfilespec.rntuple.schema import (
     ExtraTypeInformation,
     FieldDescription,
 )
-from rootfilespec.serializable import DataFetcher, serializable
+from rootfilespec.serializable import (
+    Locator,
+    ReadBuffer,
+    ROOTSerializable,
+    serializable,
+)
 from rootfilespec.structutil import Fmt
 
 
@@ -85,17 +92,22 @@ class FooterEnvelope(REnvelope):
     clusterGroups: ListFrame[ClusterGroup]
     """The List Frame of Cluster Group Record Frames"""
 
-    def get_pagelists(self, fetch_data: DataFetcher) -> list[PageListEnvelope]:
+    @property
+    def pagelist_locators(self) -> list[REnvelopeLocator[PageListEnvelope]]:
+        """Get locators for all page lists in this footer."""
+        return [
+            g.pagelistLink.envelope_locator(PageListEnvelope)
+            for g in self.clusterGroups
+        ]
+
+    def get_pagelists(
+        self, fetch_data: Callable[[Locator[ROOTSerializable]], ReadBuffer]
+    ) -> list[PageListEnvelope]:
         """Get the RNTuple Page List Envelopes from the Footer Envelope.
 
         Page List Envelope Links are stored in the Cluster Group Record Frames in the Footer Envelope Payload.
         """
-
-        #### Return the Page List Envelopes
-        return [
-            g.pagelistLink.read_envelope(fetch_data, PageListEnvelope)
-            for g in self.clusterGroups
-        ]
+        return [loc.read_from(fetch_data(loc)) for loc in self.pagelist_locators]
 
 
 ENVELOPE_TYPE_MAP[0x02] = "FooterEnvelope"

--- a/src/rootfilespec/rntuple/pagelist.py
+++ b/src/rootfilespec/rntuple/pagelist.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from typing import Annotated
 
 from rootfilespec.rntuple.envelope import (
@@ -10,7 +11,12 @@ from rootfilespec.rntuple.pagelocations import (
 )
 from rootfilespec.rntuple.RFrame import ListFrame, RecordFrame
 from rootfilespec.rntuple.RPage import RPage
-from rootfilespec.serializable import DataFetcher, serializable
+from rootfilespec.serializable import (
+    Locator,
+    ReadBuffer,
+    ROOTSerializable,
+    serializable,
+)
 from rootfilespec.structutil import Fmt
 
 
@@ -59,7 +65,21 @@ class PageListEnvelope(REnvelope):
     pageLocations: ListFrame[ListFrame[PageLocations[RPageDescription]]]
     """The Page Locations Triple Nested List Frame"""
 
-    def get_pages(self, fetch_data: DataFetcher):
+    @property
+    def page_locators(self) -> list[list[list[RPageDescription]]]:
+        """Get locators for all pages in this page list.
+
+        Returns a triple-nested list structure:
+        - Top level: clusters
+        - Middle level: columns
+        - Inner level: pages
+        """
+        return [
+            [list(pagelist) for pagelist in columnlist]
+            for columnlist in self.pageLocations
+        ]
+
+    def get_pages(self, fetch_data: Callable[[Locator[ROOTSerializable]], ReadBuffer]):
         """Get the RNTuple Pages from the Page Locations Nested List Frame.
         Does not decompress the pages."""
         #### Get the Page Locations

--- a/src/rootfilespec/rntuple/pagelocations.py
+++ b/src/rootfilespec/rntuple/pagelocations.py
@@ -1,10 +1,16 @@
-from typing import Annotated
+from collections.abc import Callable
+from typing import Annotated, cast
 
 from rootfilespec.bootstrap.compression import RCompressionSettings
 from rootfilespec.rntuple.RFrame import Item, ListFrame
 from rootfilespec.rntuple.RLocator import RLocator
 from rootfilespec.rntuple.RPage import RPage
-from rootfilespec.serializable import DataFetcher, ROOTSerializable, serializable
+from rootfilespec.serializable import (
+    Locator,
+    ReadBuffer,
+    ROOTSerializable,
+    serializable,
+)
 from rootfilespec.structutil import Fmt, OptionalField
 
 
@@ -28,22 +34,40 @@ class RPageDescription(ROOTSerializable):
     locator: RLocator
     """The locator for the page."""
 
-    def get_page(self, fetch_data: DataFetcher) -> RPage:
-        """Reads the page data from the data source using the locator.
+    @property
+    def offset(self) -> int:
+        """The byte offset of the page in the file."""
+        # Note: self.locator is always StandardLocator or LargeLocator at runtime,
+        # which have offset fields. Cast needed because base RLocator doesn't have offset.
+        return cast(Locator[ROOTSerializable], self.locator).offset
+
+    @property
+    def size(self) -> int:
+        """The (compressed) size of the page data."""
+        return self.locator.size
+
+    def read_from(self, buffer: ReadBuffer) -> RPage:
+        """Read the page from the given buffer.
+
         Pages are wrapped in compression blocks (like envelopes).
         """
-
-        #### Load the (possibly compressed) Page into the buffer
-        buffer = self.locator.get_buffer(fetch_data)
-
         #### Read the page from the buffer
         page, buffer = RPage.read(buffer)
 
         if buffer:
-            msg = "RPageDescription.get_page: buffer not empty after reading page."
+            msg = "RPageDescription.read_from: buffer not empty after reading page."
             raise ValueError(msg)
 
         return page
+
+    def get_page(
+        self, fetch_data: Callable[[Locator[ROOTSerializable]], ReadBuffer]
+    ) -> RPage:
+        """Reads the page data from the data source using the locator.
+        Pages are wrapped in compression blocks (like envelopes).
+        """
+        buffer = fetch_data(self)
+        return self.read_from(buffer)
 
 
 @serializable

--- a/src/rootfilespec/serializable.py
+++ b/src/rootfilespec/serializable.py
@@ -5,6 +5,7 @@ from inspect import get_annotations
 from typing import (
     Annotated,
     Any,
+    Protocol,
     TypeVar,
     get_args,
     get_origin,
@@ -166,14 +167,13 @@ def _get_annotations(cls: type) -> dict[str, Any]:
     return get_annotations(cls)
 
 
-@dataclasses.dataclass
 class ROOTSerializable:
     """
     A base class for objects that can be serialized and deserialized from a buffer.
     """
 
     @classmethod
-    def read(cls, buffer: ReadBuffer):
+    def read(cls: type[RT], buffer: ReadBuffer) -> tuple[RT, ReadBuffer]:
         members: Members = {}
         # TODO: always loop through base classes? StreamedObject does this a special way
         members, buffer = cls.update_members(members, buffer)
@@ -351,3 +351,47 @@ def serializable(cls: type[RT]) -> type[RT]:
 
 
 DataFetcher = Callable[[int, int], ReadBuffer]
+
+T_co = TypeVar("T_co", bound=ROOTSerializable, covariant=True)
+
+
+class Locator(Protocol[T_co]):
+    """A protocol for acquiring data buffers for a given object.
+
+    This locator can be used to fetch the data and subsequently deserialize the
+    object from the buffer using the appropriate type information. It can then
+    be wrapped by a synchronous or asynchronous fetcher to get the data.
+
+    Example synchronous fetcher:
+
+    .. code-block:: python
+
+        def fetch(loc: Locator[T]) -> T:
+            seek, size = loc.offset, loc.size
+            buffer = fetch_data(seek, size)
+            return loc.read_from(buffer)
+
+    Example asynchronous fetcher:
+
+    .. code-block:: python
+
+        async def fetch(loc: Locator[T]) -> T:
+            seek, size = loc.offset, loc.size
+            buffer = await fetch_data(seek, size)
+            return loc.read_from(buffer)
+
+    """
+
+    @property
+    def offset(self) -> int:
+        """Absolute byte offset in the file where the object is located."""
+        ...
+
+    @property
+    def size(self) -> int:
+        """Size of the object in bytes."""
+        ...
+
+    def read_from(self, buffer: ReadBuffer) -> T_co:
+        """Read the object from the given buffer."""
+        ...

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -44,18 +44,35 @@ class DummyLoc:
 
 
 def _walk_RNTuple(anchor: ROOT3a3aRNTuple, fetch_data: Callable[[Locator], ReadBuffer]):
-    def old_fetch(offset: int, size: int) -> ReadBuffer:
-        return fetch_data(DummyLoc(offset, size))
+    # Collect locators (no I/O yet)
+    header_loc = anchor.header_locator
+    footer_loc = anchor.footer_locator
 
-    footer = anchor.get_footer(old_fetch)
-    pagelists = footer.get_pagelists(old_fetch)
-    for page_locations in pagelists:
-        page_locations.get_pages(old_fetch)
+    # Fetch header and footer
+    header_buffer = fetch_data(header_loc)
+    footer_buffer = fetch_data(footer_loc)
 
+    # Deserialize
+    _header = header_loc.read_from(header_buffer)
+    footer = footer_loc.read_from(footer_buffer)
 
-def _dummy_fetch(buffer: ReadBuffer, _seek: int, _size: int) -> ReadBuffer:
-    """A dummy fetch function that does nothing."""
-    return buffer
+    # Get pagelist locators (no I/O)
+    pagelist_locs = footer.pagelist_locators
+
+    # Fetch and deserialize pagelists
+    for pl_loc in pagelist_locs:
+        pl_buffer = fetch_data(pl_loc)
+        pagelist = pl_loc.read_from(pl_buffer)
+
+        # Get page locators (no I/O)
+        page_locs = pagelist.page_locators
+
+        # Fetch and deserialize pages
+        for cluster in page_locs:
+            for column in cluster:
+                for page_loc in column:
+                    page_buffer = fetch_data(page_loc)
+                    _page = page_loc.read_from(page_buffer)
 
 
 @dataclass

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -15,27 +15,42 @@ from rootfilespec.bootstrap import (
     TBasket,
     TDirectory,
 )
+from rootfilespec.bootstrap.compression import decompress
 from rootfilespec.bootstrap.streamedobject import Ref, StreamHeader
 from rootfilespec.bootstrap.strings import TString
+from rootfilespec.bootstrap.TFile import InitialReadLocator
 from rootfilespec.bootstrap.TList import TObjArray
 from rootfilespec.container import _CArrayReader
 from rootfilespec.dispatch import normalize
 from rootfilespec.dynamic import build_file_context
 from rootfilespec.serializable import (
     BufferContext,
-    DataFetcher,
+    Locator,
     ReadBuffer,
     ROOTSerializable,
+    T_co,
 )
 
 TESTABLE_FILES = [f for f in known_files if f.endswith(".root")]
 
 
-def _walk_RNTuple(anchor: ROOT3a3aRNTuple, fetch_data: DataFetcher):
-    footer = anchor.get_footer(fetch_data)
-    pagelists = footer.get_pagelists(fetch_data)
+@dataclass(frozen=True)
+class DummyLoc:
+    offset: int
+    size: int
+
+    def read_from(self, buffer: ReadBuffer) -> ROOTSerializable:
+        raise NotImplementedError()
+
+
+def _walk_RNTuple(anchor: ROOT3a3aRNTuple, fetch_data: Callable[[Locator], ReadBuffer]):
+    def old_fetch(offset: int, size: int) -> ReadBuffer:
+        return fetch_data(DummyLoc(offset, size))
+
+    footer = anchor.get_footer(old_fetch)
+    pagelists = footer.get_pagelists(old_fetch)
     for page_locations in pagelists:
-        page_locations.get_pages(fetch_data)
+        page_locations.get_pages(old_fetch)
 
 
 def _dummy_fetch(buffer: ReadBuffer, _seek: int, _size: int) -> ReadBuffer:
@@ -101,7 +116,7 @@ class TBranchElement(TBranchObject):
 
 def _walk_branchlist(
     branchlist: TObjArray,
-    fetch_data: DataFetcher,
+    fetch_data: Callable[[Locator], ReadBuffer],
     notimplemented_callback: Callable[[bytes, NotImplementedError], None],
     path: bytes = b"",
     indent: int = 0,
@@ -148,18 +163,29 @@ def _walk_branchlist(
                 continue
             # TODO: hacky fix for: tests/test_read.py:149: error: Argument 1 has incompatible type "signedinteger[_64Bit]"; expected "int"  [arg-type] (also happened for "signedinteger[_32Bit]")
             # buffer = fetch_data(seek, size)
-            buffer = fetch_data(int(seek), int(size))
-            basket, _ = TBasket.read(buffer)
-            # TODO: this is a bit of a hack to avoid writing the same decompression code as in TKey.read_object
-            basket.read_object(
-                partial(_dummy_fetch, buffer),
-                _ReadBasket(typename, basket.bheader.fNevBuf),
-            )
+            buffer = fetch_data(DummyLoc(seek, size))
+            basket, buffer = TBasket.read(buffer)
+            if len(buffer) == 0:
+                if basket.fBuffer is None:
+                    msg = "Expected to read a basket with data, but got an empty buffer"
+                    raise ValueError(msg)
+                buffer = ReadBuffer(
+                    basket.fBuffer,
+                    basket.header.fKeylen,  # TODO: unsure if this is correct
+                    buffer.file_context,
+                    BufferContext(abspos=None),
+                )
+            if basket.header.fKeylen != buffer.relpos:
+                msg = f"Expected to be at the end of the key after reading the basket, but got {buffer.relpos} != {basket.header.fKeylen}"
+                raise ValueError(msg)
+            if len(buffer) != basket.header.fObjlen:
+                buffer = decompress(buffer, basket.header.fObjlen)
+            _ReadBasket(typename, basket.bheader.fNevBuf).read(buffer)
 
 
 def _walk(
     dir: TDirectory,
-    fetch_data: DataFetcher,
+    fetch_data: Callable[[Locator], ReadBuffer],
     notimplemented_callback: Callable[[bytes, NotImplementedError], None],
     *,
     depth=0,
@@ -169,11 +195,20 @@ def _walk(
     if dir.fSeekKeys == 0:
         # empty directory
         return
-    keylist = dir.get_KeyList(fetch_data)
+
+    buffer = fetch_data(dir.keylist_locator)
+    try:
+        keylist_key = dir.keylist_locator.read_from(buffer)
+        keylist = keylist_key.read_from(buffer)
+    except NotImplementedError as ex:
+        notimplemented_callback(path, ex)
+        return
+
     for item in keylist.values():
         itempath = path + item.fName.fString
+        buffer = fetch_data(item)
         try:
-            obj = item.read_object(fetch_data)
+            obj = item.read_from(buffer)
         except NotImplementedError as ex:
             notimplemented_callback(itempath, ex)
             continue
@@ -189,17 +224,28 @@ def _walk(
             _walk_RNTuple(obj, fetch_data)
         elif type(obj).__name__ == "TTree":
             _walk_branchlist(
-                obj.fBranches, fetch_data, notimplemented_callback, itempath + b"/"
+                obj.fBranches,  # type: ignore[attr-defined]
+                fetch_data,
+                notimplemented_callback,
+                itempath + b"/",
             )
+
+
+def fetch_cached(buffer: ReadBuffer, loc: Locator[T_co]) -> T_co:
+    seek, size = loc.offset, loc.size
+    if seek + size <= len(buffer):
+        return loc.read_from(buffer[seek : seek + size])
+    msg = "Didn't find data in cached buffer"
+    raise ValueError(msg)
 
 
 @pytest.mark.parametrize("filename", TESTABLE_FILES)
 def test_read_file(filename: str):
-    initial_read_size = 512
     path = Path(data_path(filename))
     with path.open("rb") as filehandle:
 
-        def fetch_data(seek: int, size: int):
+        def fetch_buffer(loc: Locator):
+            seek, size = loc.offset, loc.size
             filehandle.seek(seek)
             return ReadBuffer(
                 memoryview(filehandle.read(size)),
@@ -208,17 +254,13 @@ def test_read_file(filename: str):
                 BufferContext(abspos=seek),
             )
 
-        buffer = fetch_data(0, initial_read_size)
+        buffer = fetch_buffer(InitialReadLocator())
         file, _ = ROOTFile.read(buffer)
 
-        # Read root directory object, which should be contained in the initial buffer
-        def fetch_cached(seek: int, size: int):
-            if seek + size <= len(buffer):
-                return buffer[seek : seek + size]
-            msg = "Didn't find data in initial read buffer"
-            raise ValueError(msg)
-
-        rootdir = file.get_TFile(fetch_cached).rootdir
+        fetch_begin = partial(fetch_cached, buffer)
+        tfilekey = fetch_begin(file.tfile_locator)
+        tfile = fetch_begin(tfilekey)
+        rootdir = tfile.rootdir
 
         # List to collect NotImplementedError messages
         failures: list[str] = []
@@ -227,14 +269,24 @@ def test_read_file(filename: str):
             print(f"NotImplementedError: {ex}")
             failures.append(str(ex))
 
+        buffer = None
         # Read all StreamerInfo (class definitions) from the file
-        streamerinfo = file.get_StreamerInfo(fetch_data)
-        if not streamerinfo:
+        # two test files have non-null locators but they point beyond the end of
+        # the file, so we have to check for that
+        if file.streamerinfo_locator:
+            buffer = fetch_buffer(file.streamerinfo_locator)
+
+        if not buffer:
             # Try to read all objects anyway
-            _walk(rootdir, fetch_data, fail_cb)
+            _walk(rootdir, fetch_buffer, fail_cb)
             if failures:
                 return pytest.xfail(reason=",".join(set(failures)))
             return None
+
+        assert file.streamerinfo_locator is not None
+        # this buffer should contain the key and the TList of StreamerInfo
+        streamerinfokey = file.streamerinfo_locator.read_from(buffer)
+        streamerinfo = streamerinfokey.read_from(buffer)
 
         # Render the class definitions into python code
         try:
@@ -243,7 +295,8 @@ def test_read_file(filename: str):
             return pytest.xfail(reason=str(ex))
 
         # Define a new fetcher now that we can interpret the file data
-        def fetch_after_streamers(seek: int, size: int):
+        def fetch_after_streamers(loc: Locator) -> ReadBuffer:
+            seek, size = loc.offset, loc.size
             print(f"fetch_data {seek=} {size=}")
             filehandle.seek(seek)
             return ReadBuffer(

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -175,6 +175,10 @@ def _walk_branchlist(
                     buffer.file_context,
                     BufferContext(abspos=None),
                 )
+            else:
+                # TODO: does the basket always own the buffer?
+                msg = "TODO: basket doesn't own its buffer! Existing code might be OK"
+                raise ValueError(msg)
             if basket.header.fKeylen != buffer.relpos:
                 msg = f"Expected to be at the end of the key after reading the basket, but got {buffer.relpos} != {basket.header.fKeylen}"
                 raise ValueError(msg)

--- a/tests/test_rntuple_hardcoded.py
+++ b/tests/test_rntuple_hardcoded.py
@@ -37,6 +37,9 @@ def test_read_contributors():
                 BufferContext(abspos=seek),
             )
 
+        def fetch_from_locator(loc):
+            return fetch_data(loc.offset, loc.size)
+
         buffer = fetch_data(0, 512)
         file, _ = ROOTFile.read(buffer)
         tfile = file.get_TFile(fetch_data)
@@ -57,7 +60,7 @@ def test_read_contributors():
             fMaxKeySize=1073741824,
         )
 
-        rntuple = RNTuple.from_anchor(anchor, fetch_data)
+        rntuple = RNTuple.from_anchor(anchor, fetch_from_locator)
         assert rntuple == RNTuple(
             headerEnvelope=HeaderEnvelope(
                 typeID=1,
@@ -415,6 +418,9 @@ def test_read_multiple_rntuples():
                 BufferContext(abspos=seek),
             )
 
+        def fetch_from_locator(loc):
+            return fetch_data(loc.offset, loc.size)
+
         buffer = fetch_data(0, 512)
         file, _ = ROOTFile.read(buffer)
         tfile = file.get_TFile(fetch_data)
@@ -435,7 +441,7 @@ def test_read_multiple_rntuples():
             fMaxKeySize=1073741824,
         )
 
-        rntuple_a = RNTuple.from_anchor(anchor_a, fetch_data)
+        rntuple_a = RNTuple.from_anchor(anchor_a, fetch_from_locator)
         assert rntuple_a == RNTuple(
             headerEnvelope=HeaderEnvelope(
                 typeID=1,
@@ -628,7 +634,7 @@ def test_read_multiple_rntuples():
             fMaxKeySize=1073741824,
         )
 
-        rntuple_b = RNTuple.from_anchor(anchor_b, fetch_data)
+        rntuple_b = RNTuple.from_anchor(anchor_b, fetch_from_locator)
         assert rntuple_b == RNTuple(
             headerEnvelope=HeaderEnvelope(
                 typeID=1,


### PR DESCRIPTION
The idea is explained in `docs/design.md`, but in short, to enable flexible I/O patterns (synchronous, asynchronous, or batch fetching), this library separates **data location** from **data fetching**. A new protocol `Locator` is defined.

Also, migrate to pip dependency groups (just so `uv sync` works well)